### PR TITLE
Another review at concepts organization

### DIFF
--- a/docs-source/docs/modules/concepts/pages/autonomy.adoc
+++ b/docs-source/docs/modules/concepts/pages/autonomy.adoc
@@ -1,4 +1,4 @@
-= Concept: Autonomy
+= Autonomy
 :toc:
 :toc-title: ON THIS PAGE
 :toclevels: 2

--- a/docs-source/docs/modules/concepts/pages/clustering.adoc
+++ b/docs-source/docs/modules/concepts/pages/clustering.adoc
@@ -1,4 +1,4 @@
-= Concept: Akka Cluster
+= Akka Cluster
 :toc:
 :toc-title: ON THIS PAGE
 :toclevels: 2

--- a/docs-source/docs/modules/concepts/pages/cqrs.adoc
+++ b/docs-source/docs/modules/concepts/pages/cqrs.adoc
@@ -1,4 +1,4 @@
-= Concept: Command Query Responsibility Segregation (CQRS)
+= Command Query Responsibility Segregation (CQRS)
 :toc:
 :toc-title: ON THIS PAGE
 :toclevels: 2

--- a/docs-source/docs/modules/concepts/pages/event-sourcing.adoc
+++ b/docs-source/docs/modules/concepts/pages/event-sourcing.adoc
@@ -1,4 +1,4 @@
-= Concept: Event Sourcing
+= Event Sourcing
 :toc:
 :toc-title: ON THIS PAGE
 :toclevels: 2

--- a/docs-source/docs/modules/concepts/pages/grpc-services.adoc
+++ b/docs-source/docs/modules/concepts/pages/grpc-services.adoc
@@ -1,4 +1,4 @@
-= Concept: gRPC services
+= gRPC services
 :toc:
 :toc-title: ON THIS PAGE
 :toclevels: 2

--- a/docs-source/docs/modules/concepts/pages/index.adoc
+++ b/docs-source/docs/modules/concepts/pages/index.adoc
@@ -7,7 +7,7 @@ include::partial$include.adoc[]
 
 This section explains the concepts that motivate Akka's take on how to implement microservices using Event
 Sourcing and CQRS. Microservices built using Event Sourcing and CQRS adhere to the properties of a
-link:{reacive-manifesto}[reactive system] and are often called Reactive Microsystems.
+link:{reacive-manifesto}[Reactive System] and are often called Reactive Microsystems.
 
 Read the xref:introduction-traditional-architecture.adoc[introduction] for an explanation of the motivation for
 Reactive Microsystems, and a high level overview of the key concepts that power Reactive Microsystems.

--- a/docs-source/docs/modules/concepts/pages/index.adoc
+++ b/docs-source/docs/modules/concepts/pages/index.adoc
@@ -3,21 +3,30 @@
 :toc-title: ON THIS PAGE
 :toclevels: 2
 
-include::ROOT:partial$include.adoc[]
+include::partial$include.adoc[]
 
-This section explains some of the concepts that motivate Akka's take on how to implement microservices using Event
-Sourcing and CQRS.
+This section explains the concepts that motivate Akka's take on how to implement microservices using Event
+Sourcing and CQRS. Microservices built using Event Sourcing and CQRS adhere to the properties of a
+link:{reacive-manifesto}[reactive system] and are often called Reactive Microsystems.
 
-* xref:clustering.adoc[]
+Read the xref:introduction-traditional-architecture.adoc[introduction] for an explanation of the motivation for
+Reactive Microsystems, and a high level overview of the key concepts that power Reactive Microsystems.
 
-* xref:concepts-traditional-architecture.adoc[]
+== In-depth concepts
+
+* xref:isolation.adoc[] and xref:autonomy.adoc[]
+
+
 * xref:event-sourcing.adoc[]
 * xref:internal-and-external-communication.adoc[]
 * xref:cqrs.adoc[]
-* xref:isolation.adoc[]
-* xref:autonomy.adoc[]
 
-* xref:services.adoc[]
+* xref:services.adoc[] (TODO: this item on the list is a bit out of place)
 ** xref:service-discovery.adoc[]
 ** xref:service-clients.adoc[]
 ** xref:grpc-services.adoc[]
+
+== Akka Overview
+
+* xref:clustering.adoc[]
+

--- a/docs-source/docs/modules/concepts/pages/index.adoc
+++ b/docs-source/docs/modules/concepts/pages/index.adoc
@@ -21,7 +21,9 @@ Reactive Microsystems, and a high level overview of the key concepts that power 
 * xref:internal-and-external-communication.adoc[]
 * xref:cqrs.adoc[]
 
-* xref:services.adoc[] (TODO: this item on the list is a bit out of place)
+ifdef::todo[(TODO: this last item ("What makes up a service?") is out of place, needs a new section)]
+
+* xref:services.adoc[]
 ** xref:service-discovery.adoc[]
 ** xref:service-clients.adoc[]
 ** xref:grpc-services.adoc[]

--- a/docs-source/docs/modules/concepts/pages/internal-and-external-communication.adoc
+++ b/docs-source/docs/modules/concepts/pages/internal-and-external-communication.adoc
@@ -1,4 +1,4 @@
-= Concept: Internal and External Communication
+= Internal and External Communication
 :toc:
 :toc-title: ON THIS PAGE
 :toclevels: 2

--- a/docs-source/docs/modules/concepts/pages/introduction-traditional-architecture.adoc
+++ b/docs-source/docs/modules/concepts/pages/introduction-traditional-architecture.adoc
@@ -1,4 +1,4 @@
-= Traditional architectures versus Reactive microservices
+= Overview: Traditional architectures versus Reactive Microservices
 :toc:
 :toc-title: ON THIS PAGE
 :toclevels: 3
@@ -22,7 +22,7 @@ When designed with Reactive Principles, microservices have the following charact
 * Mobility (and addressability), where a microservice can be moved at runtime but can be reached in the same way regardless of its location.
 * Own their state exclusively by managing and persisting their own state in the way that best suits its own needs.
 
-== Isolation and autonomy
+== xref:isolation.adoc[Isolation] and xref:autonomy.adoc[Autonomy]
 
 From the early days of object oriented programming and service-oriented architectures, experts have recognized the benefits of encapsulation and of loose coupling between modules. Reactive microservices offer isolation and autonomy at a level that traditional architectures cannot. When each microservice has one reason to exist and owns its own state and behavior, it gains the advantages of a https://en.wikipedia.org/wiki/Shared-nothing_architecture[Shared Nothing Architecture, window="shared_nothing"]. 
 

--- a/docs-source/docs/modules/concepts/pages/isolation.adoc
+++ b/docs-source/docs/modules/concepts/pages/isolation.adoc
@@ -1,4 +1,4 @@
-= Concept: Isolation
+= Isolation
 :toc:
 :toc-title: ON THIS PAGE
 :toclevels: 2

--- a/docs-source/docs/modules/concepts/pages/service-clients.adoc
+++ b/docs-source/docs/modules/concepts/pages/service-clients.adoc
@@ -9,7 +9,7 @@ Communicating with another service requires the client to know the service's API
 
 Service discovery
 
-* link:{location-transparency}[Location Transparency]
+* link:{glossary-location-transparency}[Location Transparency]
 * Akka Discovery via DNS
 * SRV records
 

--- a/docs-source/docs/modules/concepts/pages/service-clients.adoc
+++ b/docs-source/docs/modules/concepts/pages/service-clients.adoc
@@ -3,13 +3,13 @@
 :toc-title: ON THIS PAGE
 :toclevels: 2
 
-include::ROOT:partial$include.adoc[]
+include::partial$include.adoc[]
 
 Communicating with another service requires the client to know the service's API, transport and location.
 
 Service discovery
 
-* Location Transparency
+* link:{location-transparency}[Location Transparency]
 * Akka Discovery via DNS
 * SRV records
 

--- a/docs-source/docs/modules/concepts/pages/service-discovery.adoc
+++ b/docs-source/docs/modules/concepts/pages/service-discovery.adoc
@@ -1,4 +1,4 @@
-= Concept: Service discovery
+= Service discovery
 :toc:
 :toc-title: ON THIS PAGE
 :toclevels: 2

--- a/docs-source/docs/modules/concepts/partials/include.adoc
+++ b/docs-source/docs/modules/concepts/partials/include.adoc
@@ -1,0 +1,33 @@
+:page-partial:
+include::ROOT:partial$include.adoc[]
+
+
+// Concept module attributes
+
+// link shortcuts for `link:{akka}/typed/index.html` notation
+:responsive-reactive-manifesto: https://www.reactivemanifesto.org/
+:resilient-reactive-manifesto:  https://www.reactivemanifesto.org/
+:elastic-reactive-manifesto:  https://www.reactivemanifesto.org/
+:message-driven-reactive-manifesto:  https://www.reactivemanifesto.org/
+:reacive-manifesto: https://www.reactivemanifesto.org/
+
+
+:asynchronous: https://www.reactivemanifesto.org/glossary#Asynchronous
+:back-pressure: https://www.reactivemanifesto.org/glossary#Back-Pressure
+:batching: https://www.reactivemanifesto.org/glossary#Batching
+:component: https://www.reactivemanifesto.org/glossary#Component
+:delegation: https://www.reactivemanifesto.org/glossary#Delegation
+:failure: https://www.reactivemanifesto.org/glossary#Failure
+:error: https://www.reactivemanifesto.org/glossary#Failure
+:isolation: https://www.reactivemanifesto.org/glossary#Isolation
+:location-transparency: https://www.reactivemanifesto.org/glossary#Location-Transparency
+:message-driven: https://www.reactivemanifesto.org/glossary#Message-Driven
+:non-blocking: https://www.reactivemanifesto.org/glossary#Non-Blocking
+:protocol: https://www.reactivemanifesto.org/glossary#Protocol
+:replication: https://www.reactivemanifesto.org/glossary#Replication
+:resource: https://www.reactivemanifesto.org/glossary#Resource
+:scalability: https://www.reactivemanifesto.org/glossary#Scalability
+:system: https://www.reactivemanifesto.org/glossary#System
+:user: https://www.reactivemanifesto.org/glossary#User
+
+

--- a/docs-source/docs/modules/concepts/partials/include.adoc
+++ b/docs-source/docs/modules/concepts/partials/include.adoc
@@ -5,29 +5,25 @@ include::ROOT:partial$include.adoc[]
 // Concept module attributes
 
 // link shortcuts for `link:{akka}/typed/index.html` notation
-:responsive-reactive-manifesto: https://www.reactivemanifesto.org/
-:resilient-reactive-manifesto:  https://www.reactivemanifesto.org/
-:elastic-reactive-manifesto:  https://www.reactivemanifesto.org/
-:message-driven-reactive-manifesto:  https://www.reactivemanifesto.org/
 :reacive-manifesto: https://www.reactivemanifesto.org/
 
 
-:asynchronous: https://www.reactivemanifesto.org/glossary#Asynchronous
-:back-pressure: https://www.reactivemanifesto.org/glossary#Back-Pressure
-:batching: https://www.reactivemanifesto.org/glossary#Batching
-:component: https://www.reactivemanifesto.org/glossary#Component
-:delegation: https://www.reactivemanifesto.org/glossary#Delegation
-:failure: https://www.reactivemanifesto.org/glossary#Failure
-:error: https://www.reactivemanifesto.org/glossary#Failure
-:isolation: https://www.reactivemanifesto.org/glossary#Isolation
-:location-transparency: https://www.reactivemanifesto.org/glossary#Location-Transparency
-:message-driven: https://www.reactivemanifesto.org/glossary#Message-Driven
-:non-blocking: https://www.reactivemanifesto.org/glossary#Non-Blocking
-:protocol: https://www.reactivemanifesto.org/glossary#Protocol
-:replication: https://www.reactivemanifesto.org/glossary#Replication
-:resource: https://www.reactivemanifesto.org/glossary#Resource
-:scalability: https://www.reactivemanifesto.org/glossary#Scalability
-:system: https://www.reactivemanifesto.org/glossary#System
-:user: https://www.reactivemanifesto.org/glossary#User
+:glossary-asynchronous: https://www.reactivemanifesto.org/glossary#Asynchronous
+:glossary-back-pressure: https://www.reactivemanifesto.org/glossary#Back-Pressure
+:glossary-batching: https://www.reactivemanifesto.org/glossary#Batching
+:glossary-component: https://www.reactivemanifesto.org/glossary#Component
+:glossary-delegation: https://www.reactivemanifesto.org/glossary#Delegation
+:glossary-failure: https://www.reactivemanifesto.org/glossary#Failure
+:glossary-error: https://www.reactivemanifesto.org/glossary#Failure
+:glossary-isolation: https://www.reactivemanifesto.org/glossary#Isolation
+:glossary-location-transparency: https://www.reactivemanifesto.org/glossary#Location-Transparency
+:glossary-message-driven: https://www.reactivemanifesto.org/glossary#Message-Driven
+:glossary-non-blocking: https://www.reactivemanifesto.org/glossary#Non-Blocking
+:glossary-protocol: https://www.reactivemanifesto.org/glossary#Protocol
+:glossary-replication: https://www.reactivemanifesto.org/glossary#Replication
+:glossary-resource: https://www.reactivemanifesto.org/glossary#Resource
+:glossary-scalability: https://www.reactivemanifesto.org/glossary#Scalability
+:glossary-system: https://www.reactivemanifesto.org/glossary#System
+:glossary-user: https://www.reactivemanifesto.org/glossary#User
 
 


### PR DESCRIPTION
References #59

1. Introduces a `concepts/` specific partial page with links to all words in the reactive manifesto glossary.
2. Reorders the contents in `index` page for concepts.
3. Adds an introduction to the `index` page for concepts.

