### PR TITLE
Applies the refactor on build.sbt files (see the seed)

### DIFF
--- a/docs-source/docs/modules/how-to/examples/shopping-cart-service-scala/build.sbt
+++ b/docs-source/docs/modules/how-to/examples/shopping-cart-service-scala/build.sbt
@@ -24,8 +24,8 @@ val AkkaVersion = "2.6.9"
 val AkkaHttpVersion = "10.2.0"
 // FIXME once akka management 1.0.9 is released
 val AkkaManagementVersion = "1.0.8+35-9feaa689+20200825-1429"
-val AkkaPersistenceCassandraVersion = "1.0.1"
-val AlpakkaKafkaVersion = "2.0.4"
+val AkkaPersistenceCassandraVersion = "1.0.2"
+val AlpakkaKafkaVersion = "2.0.5"
 val AkkaProjectionVersion = "1.0.0"
 
 enablePlugins(AkkaGrpcPlugin)

--- a/docs-source/docs/modules/how-to/examples/shopping-cart-service-scala/build.sbt
+++ b/docs-source/docs/modules/how-to/examples/shopping-cart-service-scala/build.sbt
@@ -1,14 +1,3 @@
-// FIXME once akka 2.6.9 is released
-val AkkaVersion = "2.6.8+71-57fb9e90"
-val AkkaPersistenceCassandraVersion = "1.0.1"
-val AlpakkaKafkaVersion = "2.0.4"
-val AkkaHttpVersion = "10.2.0"
-// FIXME once akka management 1.0.9 is released
-val AkkaManagementVersion = "1.0.8+35-9feaa689+20200825-1429"
-val AkkaProjectionVersion = "1.0.0-RC1"
-
-enablePlugins(AkkaGrpcPlugin)
-
 name := "shopping-cart-service-scala"
 version := "1.0"
 
@@ -16,10 +5,7 @@ organization := "com.lightbend.akka.samples"
 organizationHomepage := Some(url("https://akka.io"))
 licenses := Seq(("CC0", url("https://creativecommons.org/publicdomain/zero/1.0")))
 
-// For akka management snapshot
-resolvers += Resolver.bintrayRepo("akka", "snapshots")
-// For akka nightlies
-resolvers += "Akka Snapshots" at "https://repo.akka.io/snapshots/"
+scalaVersion := "2.13.3"
 
 Compile / scalacOptions ++= Seq("-deprecation", "-feature", "-unchecked", "-Xlog-reflective-calls", "-Xlint")
 Compile / javacOptions ++= Seq("-Xlint:unchecked", "-Xlint:deprecation")
@@ -28,35 +14,57 @@ Test / parallelExecution := false
 Test / testOptions += Tests.Argument("-oDF")
 Test / logBuffered := false
 
-scalaVersion := "2.13.3"
-//tag::libraryDependencies[]
-libraryDependencies ++= Seq(
-  "com.typesafe.akka" %% "akka-cluster-sharding-typed" % AkkaVersion,
-  "com.typesafe.akka" %% "akka-stream" % AkkaVersion,
-  "com.typesafe.akka" %% "akka-persistence-cassandra" % AkkaPersistenceCassandraVersion,
-  "com.lightbend.akka" %% "akka-projection-eventsourced" % AkkaProjectionVersion,
-  "com.lightbend.akka" %% "akka-projection-cassandra" % AkkaProjectionVersion,
-  "com.typesafe.akka" %% "akka-http" % AkkaHttpVersion,
-  "com.typesafe.akka" %% "akka-http2-support" % AkkaHttpVersion,
-  "com.typesafe.akka" %% "akka-http-spray-json" % AkkaHttpVersion,
-  "com.lightbend.akka.management" %% "akka-management" % AkkaManagementVersion,
-  "com.lightbend.akka.management" %% "akka-management-cluster-http" % AkkaManagementVersion,
-  "com.lightbend.akka.management" %% "akka-management-cluster-bootstrap" % AkkaManagementVersion,
-  "com.typesafe.akka" %% "akka-persistence-typed" % AkkaVersion,
-  "com.typesafe.akka" %% "akka-persistence-query" % AkkaVersion,
-  "com.typesafe.akka" %% "akka-serialization-jackson" % AkkaVersion,
-  "com.typesafe.akka" %% "akka-discovery" % AkkaVersion,
-  "com.typesafe.akka" %% "akka-stream-kafka" % AlpakkaKafkaVersion,
-  // Logging
-  "com.typesafe.akka" %% "akka-slf4j" % AkkaVersion,
-  "ch.qos.logback" % "logback-classic" % "1.2.3",
-  // Test dependencies
-  "com.typesafe.akka" %% "akka-actor-testkit-typed" % AkkaVersion % Test,
-  "com.typesafe.akka" %% "akka-persistence-testkit" % AkkaVersion % Test,
-  "com.typesafe.akka" %% "akka-stream-testkit" % AkkaVersion % Test,
-  "com.lightbend.akka" %% "akka-projection-testkit" % AkkaProjectionVersion % Test,
-  "org.scalatest" %% "scalatest" % "3.1.2" % Test)
-//end::libraryDependencies[]
-
 run / fork := false
 Global / cancelable := false // ctrl-c
+
+// For akka management snapshot
+resolvers += Resolver.bintrayRepo("akka", "snapshots")
+
+val AkkaVersion = "2.6.9"
+val AkkaHttpVersion = "10.2.0"
+// FIXME once akka management 1.0.9 is released
+val AkkaManagementVersion = "1.0.8+35-9feaa689+20200825-1429"
+val AkkaPersistenceCassandraVersion = "1.0.1"
+val AlpakkaKafkaVersion = "2.0.4"
+val AkkaProjectionVersion = "1.0.0"
+
+enablePlugins(AkkaGrpcPlugin)
+
+libraryDependencies ++= Seq(
+  // 1. Basic dependencies for a clustered application
+  "com.typesafe.akka" %% "akka-stream" % AkkaVersion,
+  "com.typesafe.akka" %% "akka-cluster-typed" % AkkaVersion,
+  "com.typesafe.akka" %% "akka-cluster-sharding-typed" % AkkaVersion,
+  "com.typesafe.akka" %% "akka-actor-testkit-typed" % AkkaVersion % Test,
+  "com.typesafe.akka" %% "akka-stream-testkit" % AkkaVersion % Test,
+
+  // Akka Management powers Health Checks and Akka Cluster Bootstrapping
+  "com.lightbend.akka.management" %% "akka-management" % AkkaManagementVersion,
+  "com.typesafe.akka" %% "akka-http" % AkkaHttpVersion,
+  "com.typesafe.akka" %% "akka-http-spray-json" % AkkaHttpVersion,
+  "com.lightbend.akka.management" %% "akka-management-cluster-http" % AkkaManagementVersion,
+  "com.lightbend.akka.management" %% "akka-management-cluster-bootstrap" % AkkaManagementVersion,
+  "com.typesafe.akka" %% "akka-discovery" % AkkaVersion,
+
+  // Common dependencies for logging and testing
+  "com.typesafe.akka" %% "akka-slf4j" % AkkaVersion,
+  "ch.qos.logback" % "logback-classic" % "1.2.3",
+  "org.scalatest" %% "scalatest" % "3.1.2" % Test,
+
+  // 2. Using gRPC and/or protobuf
+  "com.typesafe.akka" %% "akka-http2-support" % AkkaHttpVersion,
+
+  // 3. Using Akka Persistence
+  "com.typesafe.akka" %% "akka-persistence-typed" % AkkaVersion,
+  "com.typesafe.akka" %% "akka-serialization-jackson" % AkkaVersion,
+  "com.typesafe.akka" %% "akka-persistence-cassandra" % AkkaPersistenceCassandraVersion,
+  "com.typesafe.akka" %% "akka-persistence-testkit" % AkkaVersion % Test,
+
+  // 4. Querying or projecting data from Akka Persistence
+  "com.typesafe.akka" %% "akka-persistence-query" % AkkaVersion,
+  "com.lightbend.akka" %% "akka-projection-eventsourced" % AkkaProjectionVersion,
+  "com.lightbend.akka" %% "akka-projection-cassandra" % AkkaProjectionVersion,
+  "com.typesafe.akka" %% "akka-stream-kafka" % AlpakkaKafkaVersion,
+  "com.lightbend.akka" %% "akka-projection-testkit" % AkkaProjectionVersion % Test,
+)
+

--- a/docs-source/docs/modules/how-to/pages/health-checks.adoc
+++ b/docs-source/docs/modules/how-to/pages/health-checks.adoc
@@ -22,6 +22,8 @@ The {akka-management}/[Akka Management] library includes support for exposing re
 
 The depedencies for Akka Management include the core module and the cluster HTTP module for cluster inspection. As Akka Management uses Spray JSON internally, make sure to add that dependency of the exact same version as other Akka HTTP libraries.
 
+ifdef::todo[TODO: use an include instead of a hardcoded snippet below)]
+
 .build.sbt
 [source,scala]
 ----

--- a/docs-source/docs/modules/microservices-tutorial/examples/shopping-analytics-service-scala/build.sbt
+++ b/docs-source/docs/modules/microservices-tutorial/examples/shopping-analytics-service-scala/build.sbt
@@ -24,8 +24,8 @@ val AkkaVersion = "2.6.9"
 val AkkaHttpVersion = "10.2.0"
 // FIXME once akka management 1.0.9 is released
 val AkkaManagementVersion = "1.0.8+35-9feaa689+20200825-1429"
-val AkkaPersistenceCassandraVersion = "1.0.1"
-val AlpakkaKafkaVersion = "2.0.4"
+val AkkaPersistenceCassandraVersion = "1.0.2"
+val AlpakkaKafkaVersion = "2.0.5"
 val AkkaProjectionVersion = "1.0.0"
 
 enablePlugins(AkkaGrpcPlugin)

--- a/docs-source/docs/modules/microservices-tutorial/examples/shopping-analytics-service-scala/build.sbt
+++ b/docs-source/docs/modules/microservices-tutorial/examples/shopping-analytics-service-scala/build.sbt
@@ -1,14 +1,3 @@
-// FIXME once akka 2.6.9 is released
-val AkkaVersion = "2.6.8+71-57fb9e90"
-val AkkaPersistenceCassandraVersion = "1.0.1"
-val AlpakkaKafkaVersion = "2.0.4"
-val AkkaHttpVersion = "10.2.0"
-// FIXME once akka management 1.0.9 is released
-val AkkaManagementVersion = "1.0.8+35-9feaa689+20200825-1429"
-val AkkaProjectionVersion = "1.0.0-RC3"
-
-enablePlugins(AkkaGrpcPlugin)
-
 name := "shopping-analytics-service-scala"
 version := "1.0"
 
@@ -16,10 +5,7 @@ organization := "com.lightbend.akka.samples"
 organizationHomepage := Some(url("https://akka.io"))
 licenses := Seq(("CC0", url("https://creativecommons.org/publicdomain/zero/1.0")))
 
-// For akka management snapshot
-resolvers += Resolver.bintrayRepo("akka", "snapshots")
-// For akka nightlies
-resolvers += "Akka Snapshots" at "https://repo.akka.io/snapshots/"
+scalaVersion := "2.13.3"
 
 Compile / scalacOptions ++= Seq("-deprecation", "-feature", "-unchecked", "-Xlog-reflective-calls", "-Xlint")
 Compile / javacOptions ++= Seq("-Xlint:unchecked", "-Xlint:deprecation")
@@ -28,33 +14,57 @@ Test / parallelExecution := false
 Test / testOptions += Tests.Argument("-oDF")
 Test / logBuffered := false
 
-scalaVersion := "2.13.3"
-libraryDependencies ++= Seq(
-  "com.typesafe.akka" %% "akka-cluster-sharding-typed" % AkkaVersion,
-  "com.typesafe.akka" %% "akka-stream" % AkkaVersion,
-  "com.typesafe.akka" %% "akka-persistence-cassandra" % AkkaPersistenceCassandraVersion,
-  "com.lightbend.akka" %% "akka-projection-eventsourced" % AkkaProjectionVersion,
-  "com.lightbend.akka" %% "akka-projection-cassandra" % AkkaProjectionVersion,
-  "com.typesafe.akka" %% "akka-http" % AkkaHttpVersion,
-  "com.typesafe.akka" %% "akka-http2-support" % AkkaHttpVersion,
-  "com.typesafe.akka" %% "akka-http-spray-json" % AkkaHttpVersion,
-  "com.lightbend.akka.management" %% "akka-management" % AkkaManagementVersion,
-  "com.lightbend.akka.management" %% "akka-management-cluster-http" % AkkaManagementVersion,
-  "com.lightbend.akka.management" %% "akka-management-cluster-bootstrap" % AkkaManagementVersion,
-  "com.typesafe.akka" %% "akka-persistence-typed" % AkkaVersion,
-  "com.typesafe.akka" %% "akka-persistence-query" % AkkaVersion,
-  "com.typesafe.akka" %% "akka-serialization-jackson" % AkkaVersion,
-  "com.typesafe.akka" %% "akka-discovery" % AkkaVersion,
-  "com.typesafe.akka" %% "akka-stream-kafka" % AlpakkaKafkaVersion,
-  // Logging
-  "com.typesafe.akka" %% "akka-slf4j" % AkkaVersion,
-  "ch.qos.logback" % "logback-classic" % "1.2.3",
-  // Test dependencies
-  "com.typesafe.akka" %% "akka-actor-testkit-typed" % AkkaVersion % Test,
-  "com.typesafe.akka" %% "akka-persistence-testkit" % AkkaVersion % Test,
-  "com.typesafe.akka" %% "akka-stream-testkit" % AkkaVersion % Test,
-  "com.lightbend.akka" %% "akka-projection-testkit" % AkkaProjectionVersion % Test,
-  "org.scalatest" %% "scalatest" % "3.1.2" % Test)
-
 run / fork := false
 Global / cancelable := false // ctrl-c
+
+// For akka management snapshot
+resolvers += Resolver.bintrayRepo("akka", "snapshots")
+
+val AkkaVersion = "2.6.9"
+val AkkaHttpVersion = "10.2.0"
+// FIXME once akka management 1.0.9 is released
+val AkkaManagementVersion = "1.0.8+35-9feaa689+20200825-1429"
+val AkkaPersistenceCassandraVersion = "1.0.1"
+val AlpakkaKafkaVersion = "2.0.4"
+val AkkaProjectionVersion = "1.0.0"
+
+enablePlugins(AkkaGrpcPlugin)
+
+libraryDependencies ++= Seq(
+  // 1. Basic dependencies for a clustered application
+  "com.typesafe.akka" %% "akka-stream" % AkkaVersion,
+  "com.typesafe.akka" %% "akka-cluster-typed" % AkkaVersion,
+  "com.typesafe.akka" %% "akka-cluster-sharding-typed" % AkkaVersion,
+  "com.typesafe.akka" %% "akka-actor-testkit-typed" % AkkaVersion % Test,
+  "com.typesafe.akka" %% "akka-stream-testkit" % AkkaVersion % Test,
+
+  // Akka Management powers Health Checks and Akka Cluster Bootstrapping
+  "com.lightbend.akka.management" %% "akka-management" % AkkaManagementVersion,
+  "com.typesafe.akka" %% "akka-http" % AkkaHttpVersion,
+  "com.typesafe.akka" %% "akka-http-spray-json" % AkkaHttpVersion,
+  "com.lightbend.akka.management" %% "akka-management-cluster-http" % AkkaManagementVersion,
+  "com.lightbend.akka.management" %% "akka-management-cluster-bootstrap" % AkkaManagementVersion,
+  "com.typesafe.akka" %% "akka-discovery" % AkkaVersion,
+
+  // Common dependencies for logging and testing
+  "com.typesafe.akka" %% "akka-slf4j" % AkkaVersion,
+  "ch.qos.logback" % "logback-classic" % "1.2.3",
+  "org.scalatest" %% "scalatest" % "3.1.2" % Test,
+
+  // 2. Using gRPC and/or protobuf
+  "com.typesafe.akka" %% "akka-http2-support" % AkkaHttpVersion,
+
+  // 3. Using Akka Persistence
+  "com.typesafe.akka" %% "akka-persistence-typed" % AkkaVersion,
+  "com.typesafe.akka" %% "akka-serialization-jackson" % AkkaVersion,
+  "com.typesafe.akka" %% "akka-persistence-cassandra" % AkkaPersistenceCassandraVersion,
+  "com.typesafe.akka" %% "akka-persistence-testkit" % AkkaVersion % Test,
+
+  // 4. Querying or projecting data from Akka Persistence
+  "com.typesafe.akka" %% "akka-persistence-query" % AkkaVersion,
+  "com.lightbend.akka" %% "akka-projection-eventsourced" % AkkaProjectionVersion,
+  "com.lightbend.akka" %% "akka-projection-cassandra" % AkkaProjectionVersion,
+  "com.typesafe.akka" %% "akka-stream-kafka" % AlpakkaKafkaVersion,
+  "com.lightbend.akka" %% "akka-projection-testkit" % AkkaProjectionVersion % Test,
+)
+

--- a/docs-source/docs/modules/microservices-tutorial/examples/shopping-cart-service-scala/build.sbt
+++ b/docs-source/docs/modules/microservices-tutorial/examples/shopping-cart-service-scala/build.sbt
@@ -24,8 +24,8 @@ val AkkaVersion = "2.6.9"
 val AkkaHttpVersion = "10.2.0"
 // FIXME once akka management 1.0.9 is released
 val AkkaManagementVersion = "1.0.8+35-9feaa689+20200825-1429"
-val AkkaPersistenceCassandraVersion = "1.0.1"
-val AlpakkaKafkaVersion = "2.0.4"
+val AkkaPersistenceCassandraVersion = "1.0.2"
+val AlpakkaKafkaVersion = "2.0.5"
 val AkkaProjectionVersion = "1.0.0"
 
 enablePlugins(AkkaGrpcPlugin)

--- a/docs-source/docs/modules/microservices-tutorial/examples/shopping-cart-service-scala/build.sbt
+++ b/docs-source/docs/modules/microservices-tutorial/examples/shopping-cart-service-scala/build.sbt
@@ -1,14 +1,3 @@
-// FIXME once akka 2.6.9 is released
-val AkkaVersion = "2.6.8+71-57fb9e90"
-val AkkaPersistenceCassandraVersion = "1.0.1"
-val AlpakkaKafkaVersion = "2.0.5"
-val AkkaHttpVersion = "10.2.0"
-// FIXME once akka management 1.0.9 is released
-val AkkaManagementVersion = "1.0.8+35-9feaa689+20200825-1429"
-val AkkaProjectionVersion = "1.0.0-RC3"
-
-enablePlugins(AkkaGrpcPlugin)
-
 name := "shopping-cart-service-scala"
 version := "1.0"
 
@@ -16,10 +5,7 @@ organization := "com.lightbend.akka.samples"
 organizationHomepage := Some(url("https://akka.io"))
 licenses := Seq(("CC0", url("https://creativecommons.org/publicdomain/zero/1.0")))
 
-// For akka management snapshot
-resolvers += Resolver.bintrayRepo("akka", "snapshots")
-// For akka nightlies
-resolvers += "Akka Snapshots".at("https://repo.akka.io/snapshots/")
+scalaVersion := "2.13.3"
 
 Compile / scalacOptions ++= Seq("-deprecation", "-feature", "-unchecked", "-Xlog-reflective-calls", "-Xlint")
 Compile / javacOptions ++= Seq("-Xlint:unchecked", "-Xlint:deprecation")
@@ -28,35 +14,57 @@ Test / parallelExecution := false
 Test / testOptions += Tests.Argument("-oDF")
 Test / logBuffered := false
 
-scalaVersion := "2.13.3"
-//tag::libraryDependencies[]
-libraryDependencies ++= Seq(
-  "com.typesafe.akka" %% "akka-cluster-sharding-typed" % AkkaVersion,
-  "com.typesafe.akka" %% "akka-stream" % AkkaVersion,
-  "com.typesafe.akka" %% "akka-persistence-cassandra" % AkkaPersistenceCassandraVersion,
-  "com.lightbend.akka" %% "akka-projection-eventsourced" % AkkaProjectionVersion,
-  "com.lightbend.akka" %% "akka-projection-cassandra" % AkkaProjectionVersion,
-  "com.typesafe.akka" %% "akka-http" % AkkaHttpVersion,
-  "com.typesafe.akka" %% "akka-http2-support" % AkkaHttpVersion,
-  "com.typesafe.akka" %% "akka-http-spray-json" % AkkaHttpVersion,
-  "com.lightbend.akka.management" %% "akka-management" % AkkaManagementVersion,
-  "com.lightbend.akka.management" %% "akka-management-cluster-http" % AkkaManagementVersion,
-  "com.lightbend.akka.management" %% "akka-management-cluster-bootstrap" % AkkaManagementVersion,
-  "com.typesafe.akka" %% "akka-persistence-typed" % AkkaVersion,
-  "com.typesafe.akka" %% "akka-persistence-query" % AkkaVersion,
-  "com.typesafe.akka" %% "akka-serialization-jackson" % AkkaVersion,
-  "com.typesafe.akka" %% "akka-discovery" % AkkaVersion,
-  "com.typesafe.akka" %% "akka-stream-kafka" % AlpakkaKafkaVersion,
-  // Logging
-  "com.typesafe.akka" %% "akka-slf4j" % AkkaVersion,
-  "ch.qos.logback" % "logback-classic" % "1.2.3",
-  // Test dependencies
-  "com.typesafe.akka" %% "akka-actor-testkit-typed" % AkkaVersion % Test,
-  "com.typesafe.akka" %% "akka-persistence-testkit" % AkkaVersion % Test,
-  "com.typesafe.akka" %% "akka-stream-testkit" % AkkaVersion % Test,
-  "com.lightbend.akka" %% "akka-projection-testkit" % AkkaProjectionVersion % Test,
-  "org.scalatest" %% "scalatest" % "3.1.2" % Test)
-//end::libraryDependencies[]
-
 run / fork := false
 Global / cancelable := false // ctrl-c
+
+// For akka management snapshot
+resolvers += Resolver.bintrayRepo("akka", "snapshots")
+
+val AkkaVersion = "2.6.9"
+val AkkaHttpVersion = "10.2.0"
+// FIXME once akka management 1.0.9 is released
+val AkkaManagementVersion = "1.0.8+35-9feaa689+20200825-1429"
+val AkkaPersistenceCassandraVersion = "1.0.1"
+val AlpakkaKafkaVersion = "2.0.4"
+val AkkaProjectionVersion = "1.0.0"
+
+enablePlugins(AkkaGrpcPlugin)
+
+libraryDependencies ++= Seq(
+  // 1. Basic dependencies for a clustered application
+  "com.typesafe.akka" %% "akka-stream" % AkkaVersion,
+  "com.typesafe.akka" %% "akka-cluster-typed" % AkkaVersion,
+  "com.typesafe.akka" %% "akka-cluster-sharding-typed" % AkkaVersion,
+  "com.typesafe.akka" %% "akka-actor-testkit-typed" % AkkaVersion % Test,
+  "com.typesafe.akka" %% "akka-stream-testkit" % AkkaVersion % Test,
+
+  // Akka Management powers Health Checks and Akka Cluster Bootstrapping
+  "com.lightbend.akka.management" %% "akka-management" % AkkaManagementVersion,
+  "com.typesafe.akka" %% "akka-http" % AkkaHttpVersion,
+  "com.typesafe.akka" %% "akka-http-spray-json" % AkkaHttpVersion,
+  "com.lightbend.akka.management" %% "akka-management-cluster-http" % AkkaManagementVersion,
+  "com.lightbend.akka.management" %% "akka-management-cluster-bootstrap" % AkkaManagementVersion,
+  "com.typesafe.akka" %% "akka-discovery" % AkkaVersion,
+
+  // Common dependencies for logging and testing
+  "com.typesafe.akka" %% "akka-slf4j" % AkkaVersion,
+  "ch.qos.logback" % "logback-classic" % "1.2.3",
+  "org.scalatest" %% "scalatest" % "3.1.2" % Test,
+
+  // 2. Using gRPC and/or protobuf
+  "com.typesafe.akka" %% "akka-http2-support" % AkkaHttpVersion,
+
+  // 3. Using Akka Persistence
+  "com.typesafe.akka" %% "akka-persistence-typed" % AkkaVersion,
+  "com.typesafe.akka" %% "akka-serialization-jackson" % AkkaVersion,
+  "com.typesafe.akka" %% "akka-persistence-cassandra" % AkkaPersistenceCassandraVersion,
+  "com.typesafe.akka" %% "akka-persistence-testkit" % AkkaVersion % Test,
+
+  // 4. Querying or projecting data from Akka Persistence
+  "com.typesafe.akka" %% "akka-persistence-query" % AkkaVersion,
+  "com.lightbend.akka" %% "akka-projection-eventsourced" % AkkaProjectionVersion,
+  "com.lightbend.akka" %% "akka-projection-cassandra" % AkkaProjectionVersion,
+  "com.typesafe.akka" %% "akka-stream-kafka" % AlpakkaKafkaVersion,
+  "com.lightbend.akka" %% "akka-projection-testkit" % AkkaProjectionVersion % Test,
+)
+

--- a/docs-source/docs/modules/microservices-tutorial/examples/shopping-cart-service-scala/project/plugins.sbt
+++ b/docs-source/docs/modules/microservices-tutorial/examples/shopping-cart-service-scala/project/plugins.sbt
@@ -1,3 +1,2 @@
-//tag::libraryDependencies[]
+
 addSbtPlugin("com.lightbend.akka.grpc" % "sbt-akka-grpc" % "1.0.1")
-//end::libraryDependencies[]

--- a/docs-source/docs/modules/microservices-tutorial/examples/shopping-order-service-scala/build.sbt
+++ b/docs-source/docs/modules/microservices-tutorial/examples/shopping-order-service-scala/build.sbt
@@ -24,8 +24,8 @@ val AkkaVersion = "2.6.9"
 val AkkaHttpVersion = "10.2.0"
 // FIXME once akka management 1.0.9 is released
 val AkkaManagementVersion = "1.0.8+35-9feaa689+20200825-1429"
-val AkkaPersistenceCassandraVersion = "1.0.1"
-val AlpakkaKafkaVersion = "2.0.4"
+val AkkaPersistenceCassandraVersion = "1.0.2"
+val AlpakkaKafkaVersion = "2.0.5"
 val AkkaProjectionVersion = "1.0.0"
 
 enablePlugins(AkkaGrpcPlugin)

--- a/docs-source/docs/modules/microservices-tutorial/examples/shopping-order-service-scala/build.sbt
+++ b/docs-source/docs/modules/microservices-tutorial/examples/shopping-order-service-scala/build.sbt
@@ -1,14 +1,3 @@
-// FIXME once akka 2.6.9 is released
-val AkkaVersion = "2.6.8+71-57fb9e90"
-val AkkaPersistenceCassandraVersion = "1.0.1"
-val AlpakkaKafkaVersion = "2.0.4"
-val AkkaHttpVersion = "10.2.0"
-// FIXME once akka management 1.0.9 is released
-val AkkaManagementVersion = "1.0.8+35-9feaa689+20200825-1429"
-val AkkaProjectionVersion = "1.0.0-RC3"
-
-enablePlugins(AkkaGrpcPlugin)
-
 name := "shopping-order-service-scala"
 version := "1.0"
 
@@ -16,10 +5,7 @@ organization := "com.lightbend.akka.samples"
 organizationHomepage := Some(url("https://akka.io"))
 licenses := Seq(("CC0", url("https://creativecommons.org/publicdomain/zero/1.0")))
 
-// For akka management snapshot
-resolvers += Resolver.bintrayRepo("akka", "snapshots")
-// For akka nightlies
-resolvers += "Akka Snapshots" at "https://repo.akka.io/snapshots/"
+scalaVersion := "2.13.3"
 
 Compile / scalacOptions ++= Seq("-deprecation", "-feature", "-unchecked", "-Xlog-reflective-calls", "-Xlint")
 Compile / javacOptions ++= Seq("-Xlint:unchecked", "-Xlint:deprecation")
@@ -28,33 +14,57 @@ Test / parallelExecution := false
 Test / testOptions += Tests.Argument("-oDF")
 Test / logBuffered := false
 
-scalaVersion := "2.13.3"
-libraryDependencies ++= Seq(
-  "com.typesafe.akka" %% "akka-cluster-sharding-typed" % AkkaVersion,
-  "com.typesafe.akka" %% "akka-stream" % AkkaVersion,
-  "com.typesafe.akka" %% "akka-persistence-cassandra" % AkkaPersistenceCassandraVersion,
-  "com.lightbend.akka" %% "akka-projection-eventsourced" % AkkaProjectionVersion,
-  "com.lightbend.akka" %% "akka-projection-cassandra" % AkkaProjectionVersion,
-  "com.typesafe.akka" %% "akka-http" % AkkaHttpVersion,
-  "com.typesafe.akka" %% "akka-http2-support" % AkkaHttpVersion,
-  "com.typesafe.akka" %% "akka-http-spray-json" % AkkaHttpVersion,
-  "com.lightbend.akka.management" %% "akka-management" % AkkaManagementVersion,
-  "com.lightbend.akka.management" %% "akka-management-cluster-http" % AkkaManagementVersion,
-  "com.lightbend.akka.management" %% "akka-management-cluster-bootstrap" % AkkaManagementVersion,
-  "com.typesafe.akka" %% "akka-persistence-typed" % AkkaVersion,
-  "com.typesafe.akka" %% "akka-persistence-query" % AkkaVersion,
-  "com.typesafe.akka" %% "akka-serialization-jackson" % AkkaVersion,
-  "com.typesafe.akka" %% "akka-discovery" % AkkaVersion,
-  "com.typesafe.akka" %% "akka-stream-kafka" % AlpakkaKafkaVersion,
-  // Logging
-  "com.typesafe.akka" %% "akka-slf4j" % AkkaVersion,
-  "ch.qos.logback" % "logback-classic" % "1.2.3",
-  // Test dependencies
-  "com.typesafe.akka" %% "akka-actor-testkit-typed" % AkkaVersion % Test,
-  "com.typesafe.akka" %% "akka-persistence-testkit" % AkkaVersion % Test,
-  "com.typesafe.akka" %% "akka-stream-testkit" % AkkaVersion % Test,
-  "com.lightbend.akka" %% "akka-projection-testkit" % AkkaProjectionVersion % Test,
-  "org.scalatest" %% "scalatest" % "3.1.2" % Test)
-
 run / fork := false
 Global / cancelable := false // ctrl-c
+
+// For akka management snapshot
+resolvers += Resolver.bintrayRepo("akka", "snapshots")
+
+val AkkaVersion = "2.6.9"
+val AkkaHttpVersion = "10.2.0"
+// FIXME once akka management 1.0.9 is released
+val AkkaManagementVersion = "1.0.8+35-9feaa689+20200825-1429"
+val AkkaPersistenceCassandraVersion = "1.0.1"
+val AlpakkaKafkaVersion = "2.0.4"
+val AkkaProjectionVersion = "1.0.0"
+
+enablePlugins(AkkaGrpcPlugin)
+
+libraryDependencies ++= Seq(
+  // 1. Basic dependencies for a clustered application
+  "com.typesafe.akka" %% "akka-stream" % AkkaVersion,
+  "com.typesafe.akka" %% "akka-cluster-typed" % AkkaVersion,
+  "com.typesafe.akka" %% "akka-cluster-sharding-typed" % AkkaVersion,
+  "com.typesafe.akka" %% "akka-actor-testkit-typed" % AkkaVersion % Test,
+  "com.typesafe.akka" %% "akka-stream-testkit" % AkkaVersion % Test,
+
+  // Akka Management powers Health Checks and Akka Cluster Bootstrapping
+  "com.lightbend.akka.management" %% "akka-management" % AkkaManagementVersion,
+  "com.typesafe.akka" %% "akka-http" % AkkaHttpVersion,
+  "com.typesafe.akka" %% "akka-http-spray-json" % AkkaHttpVersion,
+  "com.lightbend.akka.management" %% "akka-management-cluster-http" % AkkaManagementVersion,
+  "com.lightbend.akka.management" %% "akka-management-cluster-bootstrap" % AkkaManagementVersion,
+  "com.typesafe.akka" %% "akka-discovery" % AkkaVersion,
+
+  // Common dependencies for logging and testing
+  "com.typesafe.akka" %% "akka-slf4j" % AkkaVersion,
+  "ch.qos.logback" % "logback-classic" % "1.2.3",
+  "org.scalatest" %% "scalatest" % "3.1.2" % Test,
+
+  // 2. Using gRPC and/or protobuf
+  "com.typesafe.akka" %% "akka-http2-support" % AkkaHttpVersion,
+
+  // 3. Using Akka Persistence
+  "com.typesafe.akka" %% "akka-persistence-typed" % AkkaVersion,
+  "com.typesafe.akka" %% "akka-serialization-jackson" % AkkaVersion,
+  "com.typesafe.akka" %% "akka-persistence-cassandra" % AkkaPersistenceCassandraVersion,
+  "com.typesafe.akka" %% "akka-persistence-testkit" % AkkaVersion % Test,
+
+  // 4. Querying or projecting data from Akka Persistence
+  "com.typesafe.akka" %% "akka-persistence-query" % AkkaVersion,
+  "com.lightbend.akka" %% "akka-projection-eventsourced" % AkkaProjectionVersion,
+  "com.lightbend.akka" %% "akka-projection-cassandra" % AkkaProjectionVersion,
+  "com.typesafe.akka" %% "akka-stream-kafka" % AlpakkaKafkaVersion,
+  "com.lightbend.akka" %% "akka-projection-testkit" % AkkaProjectionVersion % Test,
+)
+


### PR DESCRIPTION
https://github.com/akka/akka-microservices-seed-scala.g8/pull/3
and 
https://github.com/akka/akka-microservices-seed-scala.g8/pull/4


The changes in this PR include adding this dependency: (other than reordering and bumping versions)

`"com.typesafe.akka" %% "akka-cluster-typed" % AkkaVersion,`