### PR TITLE
List tutorial steps and how-tos on index page

### DIFF
--- a/docs-source/docs/modules/ROOT/pages/index.adoc
+++ b/docs-source/docs/modules/ROOT/pages/index.adoc
@@ -13,7 +13,7 @@ The tutorials in this guide show end-to-end use-cases implemented in Akka with t
 
 == How to get the most out of this guide
 
-For a code-first experience, have a look at the xref:shopping-microservices:index.adoc[Implementing Microservices with Akka tutorial] which walks you through an example project and explains how features from the Akka ecosystem fit together to build Reactive Systems. The tutorial will point you to the relevant xref::concepts:index.adoc[concepts] where applicable.
+For a code-first experience, have a look at the xref:microservices-tutorial:index.adoc[Implementing Microservices with Akka tutorial] which walks you through an example project and explains how features from the Akka ecosystem fit together to build Reactive Systems. The tutorial will point you to the relevant xref::concepts:index.adoc[concepts] where applicable.
 
 If this is your first experience with Reactive frameworks or with Akka, we present some background and ideas behind _Reactive_ in the xref:concepts:index.adoc[Concepts section]. You can read those when they are introduced in the tutorial, or read them first if you prefer a more theoretical overview before diving into the code. There you will learn:
 
@@ -26,10 +26,14 @@ ifdef::todo[TODO:
 
 == Akka Microservices tutorial
 
-The xref:microservices-tutorial:index.adoc[Implementing Microservices with Akka] illustrates how to implement Event Sourcing with Akka Persistence and CQRS using Akka Projections.
+The xref:microservices-tutorial:index.adoc[Implementing Microservices with Akka tutorial] illustrates how to implement Event Sourcing with Akka Persistence and CQRS using Akka Projections.
+
+include::microservices-tutorial:partial$listing.adoc[]
 
 == How to...
 
-Some development tasks arise from requirements on existing projects. The * xref:how-to:index.adoc[] section collects guidance for how to introduce a new feature or architectural improvement on an existing codebase.
+Some development tasks arise from requirements on existing projects. The xref:how-to:index.adoc[] section collects guidance for how to introduce a new feature or architectural improvement on an existing codebase.
+
+include::how-to:partial$listing.adoc[]
 
 **This documentation was last published: {localdate}**

--- a/docs-source/docs/modules/how-to/pages/index.adoc
+++ b/docs-source/docs/modules/how-to/pages/index.adoc
@@ -5,8 +5,4 @@
 
 include::partial$include.adoc[]
 
-* xref:health-checks.adoc[]
-* xref:evolve-grpc-apis.adoc[]
-* xref:enable-TLS.adoc[]
-* xref:scale-independently.adoc[]
-* xref:from-crud-to-eventsourcing.adoc[]
+include::partial$listing.adoc[]

--- a/docs-source/docs/modules/how-to/partials/listing.adoc
+++ b/docs-source/docs/modules/how-to/partials/listing.adoc
@@ -1,0 +1,7 @@
+:page-partial:
+
+* xref:how-to:health-checks.adoc[]
+* xref:how-to:evolve-grpc-apis.adoc[]
+* xref:how-to:enable-TLS.adoc[]
+* xref:how-to:scale-independently.adoc[]
+* xref:how-to:from-crud-to-eventsourcing.adoc[]

--- a/docs-source/docs/modules/microservices-tutorial/pages/index.adoc
+++ b/docs-source/docs/modules/microservices-tutorial/pages/index.adoc
@@ -11,14 +11,7 @@ This example illustrates how multiple microservices can interact to implement a 
 
 This example evolves around a shopping cart. The tutorial takes you through the following steps to build the services from scratch, and adding piece by piece with deployment to the cloud for each step.
 
-. xref:overview.adoc[Overview of the example]
-. xref:dev-env.adoc[Development environment]
-. xref:grpc-server.adoc[First gRPC service]
-. xref:entity.adoc[Event Sourced entity]
-. xref:complete-entity.adoc[Complete Event Sourced entity]
-. xref:projection-query.adoc[Projection for queries]
-. xref:projection-kafka.adoc[Projection publishing to Kafka]
-. xref:projection-grpc-client.adoc[Projection calling gRPC service]
+include::partial$listing.adoc[]
 
 == Used Akka modules
 

--- a/docs-source/docs/modules/microservices-tutorial/partials/listing.adoc
+++ b/docs-source/docs/modules/microservices-tutorial/partials/listing.adoc
@@ -1,0 +1,10 @@
+:page-partial:
+
+. xref:microservices-tutorial:overview.adoc[Overview of the example]
+. xref:microservices-tutorial:dev-env.adoc[Development environment]
+. xref:microservices-tutorial:grpc-server.adoc[First gRPC service]
+. xref:microservices-tutorial:entity.adoc[Event Sourced entity]
+. xref:microservices-tutorial:complete-entity.adoc[Complete Event Sourced entity]
+. xref:microservices-tutorial:projection-query.adoc[Projection for queries]
+. xref:microservices-tutorial:projection-kafka.adoc[Projection publishing to Kafka]
+. xref:microservices-tutorial:projection-grpc-client.adoc[Projection calling gRPC service]


### PR DESCRIPTION
This lists the steps within the tutorial and even more importantly the available how-tos on the index page.

There might be a better integrated way to achieve this.

![bild](https://user-images.githubusercontent.com/458526/92897447-7c9b4180-f41d-11ea-88e2-40e497fbe6f0.png)
