### PR TITLE
use the same CassandraSession for journal and projections

### DIFF
--- a/docs-source/docs/modules/microservices-tutorial/examples/shopping-cart-service-scala/src/main/resources/persistence.conf
+++ b/docs-source/docs/modules/microservices-tutorial/examples/shopping-cart-service-scala/src/main/resources/persistence.conf
@@ -17,6 +17,9 @@ akka {
         refresh-interval = 2s
       }
 
+      journal.keyspace = shoppingcart
+      snapshot.keyspace = shoppingcart
+
       # don't use autocreate in production
       journal.keyspace-autocreate = on
       journal.tables-autocreate = on
@@ -27,6 +30,8 @@ akka {
 
   projection {
     cassandra.offset-store.keyspace = shoppingcart
+    # use same Cassandra session config as for the journal
+    cassandra.session-config-path = "akka.persistence.cassandra"
   }
 }
 

--- a/docs-source/docs/modules/microservices-tutorial/examples/shopping-cart-service-scala/src/main/scala/shopping/cart/Main.scala
+++ b/docs-source/docs/modules/microservices-tutorial/examples/shopping-cart-service-scala/src/main/scala/shopping/cart/Main.scala
@@ -42,7 +42,7 @@ object Main {
 
     // use same keyspace for the item_popularity table as the offset store
     val keyspace = system.settings.config.getString("akka.projection.cassandra.offset-store.keyspace")
-    val session = CassandraSessionRegistry(system).sessionFor("akka.projection.cassandra.session-config")
+    val session = CassandraSessionRegistry(system).sessionFor("akka.persistence.cassandra")
     Await.result(ItemPopularityRepositoryImpl.createItemPopularityTable(session, keyspace), 30.seconds)
 
     LoggerFactory.getLogger("shopping.cart.Main").info("Created keyspace [{}] and tables", keyspace)
@@ -59,7 +59,7 @@ class Main(context: ActorContext[Nothing]) extends AbstractBehavior[Nothing](con
   ShoppingCart.init(system)
 
   // tag::ItemPopularityProjection[]
-  val session = CassandraSessionRegistry(system).sessionFor("akka.projection.cassandra.session-config") // <1>
+  val session = CassandraSessionRegistry(system).sessionFor("akka.persistence.cassandra") // <1>
   // use same keyspace for the item_popularity table as the offset store
   val itemPopularityKeyspace = system.settings.config.getString("akka.projection.cassandra.offset-store.keyspace")
   val itemPopularityRepository =

--- a/docs-source/docs/modules/microservices-tutorial/examples/shopping-cart-service-scala/src/test/scala/shopping/cart/ItemPopularityIntegrationSpec.scala
+++ b/docs-source/docs/modules/microservices-tutorial/examples/shopping-cart-service-scala/src/test/scala/shopping/cart/ItemPopularityIntegrationSpec.scala
@@ -58,7 +58,7 @@ class ItemPopularityIntegrationSpec
     with AnyWordSpecLike {
 
   private lazy val itemPopularityRepository = {
-    val session = CassandraSessionRegistry(system).sessionFor("akka.projection.cassandra.session-config")
+    val session = CassandraSessionRegistry(system).sessionFor("akka.persistence.cassandra")
     // use same keyspace for the item_popularity table as the offset store
     val itemPopularityKeyspace = system.settings.config.getString("akka.projection.cassandra.offset-store.keyspace")
     new ItemPopularityRepositoryImpl(session, itemPopularityKeyspace)(system.executionContext)


### PR DESCRIPTION
* more efficient and easier to configure since we don't aim for using more than one db
