### PR TITLE
log each item in ItemPopularityProjectionHandler

### DIFF
--- a/docs-source/docs/modules/microservices-tutorial/examples/shopping-cart-service-scala/src/main/scala/shopping/cart/ItemPopularityProjectionHandler.scala
+++ b/docs-source/docs/modules/microservices-tutorial/examples/shopping-cart-service-scala/src/main/scala/shopping/cart/ItemPopularityProjectionHandler.scala
@@ -10,19 +10,13 @@ import akka.projection.eventsourced.EventEnvelope
 import akka.projection.scaladsl.Handler
 import org.slf4j.LoggerFactory
 
-object ItemPopularityProjectionHandler {
-  val LogInterval = 10
-}
-
 class ItemPopularityProjectionHandler(tag: String, system: ActorSystem[_], repo: ItemPopularityRepository)
     extends Handler[EventEnvelope[ShoppingCart.Event]]() { // <1>
 
-  private var logCounter: Int = 0
   private val log = LoggerFactory.getLogger(getClass)
   private implicit val ec: ExecutionContext = system.executionContext
 
   override def process(envelope: EventEnvelope[ShoppingCart.Event]): Future[Done] = { // <2>
-    logItemCount(envelope.event)
     val processed = envelope.event match { // <3>
       case ShoppingCart.ItemAdded(_, itemId, quantity) =>
         repo.update(itemId, quantity)
@@ -45,16 +39,12 @@ class ItemPopularityProjectionHandler(tag: String, system: ActorSystem[_], repo:
   private def logItemCount(event: ShoppingCart.Event): Unit =
     event match {
       case itemEvent: ShoppingCart.ItemEvent =>
-        logCounter += 1
         val itemId = itemEvent.itemId
-        if (logCounter == ItemPopularityProjectionHandler.LogInterval) {
-          logCounter = 0
-          repo.getItem(itemId).foreach {
-            case Some(count) =>
-              log.info("ItemPopularityProjectionHandler({}) item popularity for '{}': [{}]", tag, itemId, count)
-            case None =>
-              log.info("ItemPopularityProjectionHandler({}) item popularity for '{}': [0]", tag, itemId)
-          }
+        repo.getItem(itemId).foreach {
+          case Some(count) =>
+            log.info("ItemPopularityProjectionHandler({}) item popularity for '{}': [{}]", tag, itemId, count)
+          case None =>
+            log.info("ItemPopularityProjectionHandler({}) item popularity for '{}': [0]", tag, itemId)
         }
       case _ => ()
     }


### PR DESCRIPTION
* the log every 10th is just confusing when looking at the logs
* my thought was, why is it not consuming all events?

