### PR TITLE
Add create keyspace to Cassandra script

### DIFF
--- a/docs-source/docs/modules/microservices-tutorial/examples/shopping-cart-service-scala/src/main/resources/create_tables.cql
+++ b/docs-source/docs/modules/microservices-tutorial/examples/shopping-cart-service-scala/src/main/resources/create_tables.cql
@@ -1,3 +1,6 @@
+CREATE KEYSPACE IF NOT EXISTS shoppingcart
+WITH REPLICATION = { 'class' : 'SimpleStrategy','replication_factor':1 };
+
 USE shoppingcart;
 
 CREATE TABLE IF NOT EXISTS messages (


### PR DESCRIPTION
Not clear if it was intentional to leave the `create keyspace` out, so here it is. 

I'm assuming development / test and just using the same settings suggested in https://doc.akka.io/docs/akka-persistence-cassandra/current/journal.html#schema
