### PR TITLE
Removes Event Storming section

### DIFF
--- a/docs-source/docs/modules/concepts/pages/commands-and-events.adoc
+++ b/docs-source/docs/modules/concepts/pages/commands-and-events.adoc
@@ -14,8 +14,3 @@ Events will be serialized and published into the _Journal_ table in the database
 A client trying to mutate the state of an entity will produce a command message and send it to the entity. Commands are a type of message. Sometimes, commands include the address of the sender, the entity can use the sender address to send a message back with a reply.
 
 Events are {reactive-principles}/patterns/communicate-facts.html[facts] {reactive-principles}/patterns/communicate-facts.html[{tab-icon}, window="tab"], while commands are requests for a state mutation.
-
-== Event Storming
-[#event_storming]
-
-Event Storming is a type of multi-disciplinary meeting where product specialists, developers and other roles in the company meet with the main purpose to model the business as a collection of commands, entities and events; while grouping these commands, entities and events into separate xref:ddd.adoc#bounded_context[bounded_contexts].

--- a/docs-source/docs/modules/how-to/pages/from-crud-to-eventsourcing.adoc
+++ b/docs-source/docs/modules/how-to/pages/from-crud-to-eventsourcing.adoc
@@ -79,10 +79,6 @@ In Event Sourcing, the `State` must be rebuilt in memory every time. The process
 
 See the xref:microservices-tutorial:entity.adoc[step adding an Event Sourced entity], and the xref:microservices-tutorial:complete-entity.adoc[step completing the Event Sourced entity] on the tutorial for more details.
 
-[NOTE]
-====
-An more advanced approach to enriching a CRUD model into an Event Sourcing model is to run one or many xref:concepts:commands-and-events.adoc#event_storming[Event Storming sessions].
-====
 
 == Consistency and Availability
 


### PR DESCRIPTION
As previously discussed, Event Storming is more running a brainstorm session. Although interesting, not required for building Akka Microservices. 

The page "Traditional architectures versus Reactive Microsystems" have a already a link to Kevin Weber blog post about it. That should be sufficient for those willing to learn more about it and dig the internet for more info.
