### PR TITLE
Remove unnecessary info regarding last publish

### DIFF
--- a/docs-source/docs/modules/ROOT/pages/index.adoc
+++ b/docs-source/docs/modules/ROOT/pages/index.adoc
@@ -36,4 +36,3 @@ Some development tasks arise from requirements on existing projects. The xref:ho
 
 include::how-to:partial$listing.adoc[]
 
-**This documentation was last published: {localdate}**


### PR DESCRIPTION
References #181

@rstento is this info something we want to keep around?