### PR TITLE
remove set -e in .travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -71,10 +71,8 @@ jobs:
       name: "Howto cleanup dependencies"
 
     - script:
-        - set -e
         - scripts/copy-identical-files.sh
         - git diff --exit-code --color || { echo "[error] Found modified file that was expected to be identical. Run scripts/copy-identical-files.sh"; false; }
-        - set +e
       name: "copy-identical-files"
 
     - stage: site
@@ -84,10 +82,8 @@ jobs:
 
     - stage: publish
       script:
-        - set -e
         - scripts/prepare-downloads.sh
         - scripts/deploy-site.sh
-        - set +e
       name: "Publish snapshot site"
 
 stages:


### PR DESCRIPTION
I added those because I read somewhere that it could be a way to fail-fast if one of the steps in the script failed (otherwise it continues), but that seems to have been a bad idea. Publish of docs is broken.

https://github.com/travis-ci/docs-travis-ci-com/issues/1672