### PR TITLE
Create local Docker image with Antora plugins

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,21 +1,18 @@
 SHELL_DIR := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 ROOT_DIR := ${SHELL_DIR}
 
-antora_docker_image     := antora/antora
-antora_docker_image_tag := 2.3.1
+antora_docker_image     := local/antora-doc
+antora_docker_image_tag := latest
 
 work_dir := ${ROOT_DIR}/target
 
 staging_dir := ${work_dir}/staging
-
-# javascaladoc_dir := ${staging_dir}/docs/current/api
 
 all: build
 
 local-preview: html-author-mode
 	@echo "Access the documentation on http://localhost:8000"
 	(cd target/staging/; python3 -m http.server)
-
 
 show:
 	echo work dir: ${work_dir}
@@ -24,33 +21,33 @@ show:
 clean:
 	rm -rf ${work_dir}
 
+docker-image:
+	(cd ${ROOT_DIR}/antora-docker;  docker build -t local/antora-doc:latest .)
+
 # build: clean html javascaladoc_staged print-site
 build: clean html print-site
 
-html: clean
+html: clean  docker-image
 	docker run \
 		-u $(shell id -u):$(shell id -g) \
-		--privileged \
 		-v ${ROOT_DIR}:/antora \
 		--rm \
 		-t ${antora_docker_image}:${antora_docker_image_tag} \
 		--cache-dir=./.cache/antora \
-		--stacktrace \
 		docs-source/site.yml
 	@echo "Done"
 
-html-author-mode: clean
+html-author-mode: clean docker-image
 	docker run \
 		-u $(shell id -u):$(shell id -g) \
 		-v ${ROOT_DIR}:/antora \
 		--rm \
 		-t ${antora_docker_image}:${antora_docker_image_tag} \
 		--cache-dir=./.cache/antora \
-		--stacktrace \
 		docs-source/author-mode-site.yml
 	@echo "Done"
 
-check-links:
+check-links: docker-image
 	docker run \
 		-v ${ROOT_DIR}:/antora \
 		--rm \
@@ -59,32 +56,20 @@ check-links:
 		--cache-dir=./.cache/antora \
 		-c 'find /antora/docs-source -name '*.adoc' -print0 | xargs -0 -n1 asciidoc-link-check -p -c docs-source/asciidoc-link-check-config.json'
 
-list-todos: html
+list-todos: html docker-image
 	docker run \
 		-v ${ROOT_DIR}:/antora \
 		--rm \
-		--entrypoint /bin/sh \
 		-t ${antora_docker_image}:${antora_docker_image_tag} \
 		--cache-dir=./.cache/antora \
+		--entrypoint /bin/sh \
 		-c 'find /antora/docs-source/build/site/cloudflow/${version} -name "*.html" -print0 | xargs -0 grep -iE "TODO|FIXME|REVIEWERS|adoc"'
 
-# Generate the ScalaDoc and the JavaDoc, and put it in ${output}/scaladoc and ${output}/javadoc
-# javascaladoc:
-# 	-(cd ${ROOT_DIR}/core && sbt clean unidoc )
-
-# javascaladoc_staged: ${javascaladoc_dir} javascaladoc
-# 	cp -r ${ROOT_DIR}/core/target/scala-2.12/unidoc ${javascaladoc_dir}/scaladoc
-# 	cp -r ${ROOT_DIR}/core/target/javaunidoc ${javascaladoc_dir}/javadoc
-
-${work_dir}: 
+${work_dir}:
 	mkdir -p ${work_dir}
 
 ${staging_dir}:
 	mkdir -p ${staging_dir}
-
-# ${javascaladoc_dir}:
-# 	mkdir -p ${javascaladoc_dir}/scaladoc
-# 	mkdir -p ${javascaladoc_dir}/javadoc
 
 print-site:
 	# The result directory with the contents of this build:

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ clean:
 	rm -rf ${work_dir}
 
 docker-image:
-	(cd ${ROOT_DIR}/antora-docker;  docker build -t local/antora-doc:latest .)
+	(cd ${ROOT_DIR}/antora-docker;  docker build -t ${antora_docker_image}:${antora_docker_image_tag} .)
 
 # build: clean html javascaladoc_staged print-site
 build: clean html print-site

--- a/antora-docker/Dockerfile
+++ b/antora-docker/Dockerfile
@@ -1,5 +1,14 @@
-FROM antora/antora:2.1.2
+FROM antora/antora:2.3.1
 
-RUN npm install -g asciidoc-link-check
+RUN yarn global add asciidoc-link-check
+# https://github.com/Mogztter/antora-lunr
+RUN yarn global add antora-lunr
+# https://github.com/Mogztter/antora-site-generator-lunr
+RUN yarn global add antora-site-generator-lunr
 
-LABEL description="antora/antora image with the additional 'asciidoc-link-check' tool"
+ENV DOCSEARCH_ENABLED=true
+ENV DOCSEARCH_ENGINE=lunr
+
+ENTRYPOINT ["docker-entrypoint.sh", "--stacktrace", "--generator", "antora-site-generator-lunr"]
+
+LABEL description="antora/antora image with some extensions"

--- a/antora-docker/README.md
+++ b/antora-docker/README.md
@@ -3,7 +3,7 @@
 ## Build the image
 
 ```
-docker build -t lighbend/antora-doc:<version> .
+docker build -t lightbend/antora-doc:<version> .
 ```
 
 ## Publish the image
@@ -11,7 +11,7 @@ docker build -t lighbend/antora-doc:<version> .
 Login as `lightbend` on docker. Credentials available in keybase.
 
 ```
-docker push lighbend/antora-doc:<version>
+docker push lightbend/antora-doc:<version>
 ```
 
 Note: Only contributors with access to the Lightbend credentials are able to publish this image.

--- a/antora-docker/docker-entrypoint.sh
+++ b/antora-docker/docker-entrypoint.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+# abort script if a command fails
+set -e
+
+# prepend antora if command is not detected
+if [ $# -eq 0 ] || [ "${1:0:1}" == '-' ] || [ -z `command -v "$1" || echo -n` ]; then
+  set -- antora "$@"
+fi
+
+exec "$@"


### PR DESCRIPTION
Create a local Antora Docker image with the link checker and lunr plugins and use that image to run Antora.

This can be cleaned up more once we have the correct process in place.

References #268
