### PR TITLE
Renumber tutorial; remove previous/next links

### DIFF
--- a/docs-source/docs/modules/microservices-tutorial/pages/complete-entity.adoc
+++ b/docs-source/docs/modules/microservices-tutorial/pages/complete-entity.adoc
@@ -1,4 +1,4 @@
-= Part 4: Complete Event Sourced entity
+= V: Complete Event Sourced entity
 :page-supergroup-java-scala: Language
 
 include::ROOT:partial$include.adoc[]
@@ -345,8 +345,6 @@ grpcurl -d '{"cartId":"cart2"}' -plaintext 127.0.0.1:8101 shoppingcart.ShoppingC
 
 == Learn more
 
-* In xref:projection-query.adoc[**next step**] of the tutorial you will add a Projection for queries.
-* Revisit the Event Sourced entity in xref:entity.adoc[previous step].
 * xref:concepts:event-sourcing.adoc[Event Sourcing concepts].
 * {akka}/typed/persistence.html[Akka Event Sourcing reference documentation] {akka}/typed/persistence.html[{tab-icon}, window="tab"].
 * {akka}/typed/cluster-sharding.html[Akka Cluster Sharding reference documentation] {akka}/typed/cluster-sharding.html[{tab-icon}, window="tab"].

--- a/docs-source/docs/modules/microservices-tutorial/pages/dev-env.adoc
+++ b/docs-source/docs/modules/microservices-tutorial/pages/dev-env.adoc
@@ -148,9 +148,3 @@ The example projects are using the following ports.
 |8303
 
 |===
-
-
-== Learn more
-
-* Next, xref:template.adoc[get your project] set up.
-* Revisit the overview in xref:overview.adoc[previous step].

--- a/docs-source/docs/modules/microservices-tutorial/pages/entity.adoc
+++ b/docs-source/docs/modules/microservices-tutorial/pages/entity.adoc
@@ -340,10 +340,9 @@ docker-compose down
 
 ifdef::todo[TODO deploy the updated version to the cloud and try it]
 
+:!sectnums:
 == Learn more
 
-* In xref:complete-entity.adoc[**next step**] of the tutorial you will complete the `ShoppingCart` entity.
-* Revisit the gRPC server in xref:grpc-server.adoc[previous step].
 * xref:concepts:event-sourcing.adoc[Event Sourcing concepts].
 * {akka}/typed/persistence.html[Akka Event Sourcing reference documentation] {akka}/typed/persistence.html[{tab-icon}, window="tab"].
 * {akka}/typed/cluster-sharding.html[Akka Cluster Sharding reference documentation] {akka}/typed/cluster-sharding.html[{tab-icon}, window="tab"].

--- a/docs-source/docs/modules/microservices-tutorial/pages/grpc-service.adoc
+++ b/docs-source/docs/modules/microservices-tutorial/pages/grpc-service.adoc
@@ -162,7 +162,5 @@ ifdef::todo[TODO: deploy to cloud and try it]
 :!sectnums:
 == Learn more
 
-* In xref:entity.adoc[**next step**] of the tutorial you will add an Event Sourced entity.
-* Revisit the development environment in xref:dev-env.adoc[previous step].
 * xref:concepts:grpc-services.adoc[gRPC concepts]
 * {akka-grpc}/server/index.html[Akka gRPC server reference documentation] {akka-grpc}/server/index.html[{tab-icon}, window="tab"].

--- a/docs-source/docs/modules/microservices-tutorial/pages/projection-grpc-client.adoc
+++ b/docs-source/docs/modules/microservices-tutorial/pages/projection-grpc-client.adoc
@@ -1,4 +1,4 @@
-= Part 7: Projection calling gRPC service
+= VIII: Projection calling gRPC service
 :page-supergroup-java-scala: Language
 
 include::ROOT:partial$include.adoc[]
@@ -224,6 +224,5 @@ ifdef::todo[TODO: deploy the updated shopping-cart-service and the new shopping-
 
 This is the end of the tutorial.
 
-* Revisit the Projection for publishing events to Kafka in xref:projection-kafka.adoc[previous step].
 * {akka-grpc}/client/index.html[Akka gRPC client reference documentation] {akka-grpc}/client/index.html[{tab-icon}, window="tab"].
 * {akka-projection}/[Akka Projection reference documentation] {akka-projection}/[{tab-icon}, window="tab"].

--- a/docs-source/docs/modules/microservices-tutorial/pages/projection-kafka.adoc
+++ b/docs-source/docs/modules/microservices-tutorial/pages/projection-kafka.adoc
@@ -1,4 +1,4 @@
-= Part 6: Projection publishing to Kafka
+= VII: Projection publishing to Kafka
 :page-supergroup-java-scala: Language
 
 include::ROOT:partial$include.adoc[]
@@ -248,7 +248,5 @@ ifdef::todo[TODO: deploy the updated shopping-cart-service and the new shopping-
 
 == Learn more
 
-* In xref:projection-grpc-client.adoc[**next step**] of the tutorial you will add a Projection calling a gRPC service.
-* Revisit the Projection for queries in xref:projection-query.adoc[previous step].
 * xref:concepts:internal-and-external-communication.adoc[Internal and External Communication concepts].
 * {akka-projection}/[Akka Projection reference documentation] {akka-projection}/[{tab-icon}, window="tab"].

--- a/docs-source/docs/modules/microservices-tutorial/pages/projection-query.adoc
+++ b/docs-source/docs/modules/microservices-tutorial/pages/projection-query.adoc
@@ -1,4 +1,4 @@
-= Part 5: Projection for queries
+= VI: Projection for queries
 :page-supergroup-java-scala: Language
 
 include::ROOT:partial$include.adoc[]
@@ -267,8 +267,6 @@ ifdef::todo[TODO: deploy the updated version to the cloud and try it]
 
 == Learn more
 
-* In xref:projection-kafka.adoc[**next step**] of the tutorial you will add a Projection for publishing events to Kafka.
-* Revisit the Event Sourced entity in xref:complete-entity.adoc[previous step].
 * xref:concepts:cqrs.adoc[CQRS concepts].
 * {akka-projection}/[Akka Projection reference documentation] {akka-projection}/[{tab-icon}, window="tab"].
 * {akka}/typed/cluster-sharded-daemon-process.html[Akka Sharded Daemon Process reference documentation] {akka}/typed/cluster-sharded-daemon-process.html[{tab-icon}, window="tab"].


### PR DESCRIPTION
* Correct tutorial numbering (Roman numbers)
* Remove the previous/next links as they are part of the theme now

References #268