### PR TITLE
Lightbend links in toolbar and footer.

### DIFF
--- a/docs-source/docs/antora.yml
+++ b/docs-source/docs/antora.yml
@@ -1,6 +1,6 @@
 name: "" # root
 version: "snapshot"
-title: Akka Platform Guide
+title: "" # removed title to prevent a double title entry in TOC
 nav:
 - modules/ROOT/nav.adoc
 - modules/microservices-tutorial/nav.adoc

--- a/docs-source/supplemental_ui/partials/footer-nav.hbs
+++ b/docs-source/supplemental_ui/partials/footer-nav.hbs
@@ -1,25 +1,24 @@
 <nav>
 	<section>
-		<h3>Lightbend Documentation</h3>
+		<h3>Lightbend Docs</h3>
 		<ul>
-				<li><a class="navbar-item" href="https://akka.io/docs/">Akka</a></li>
-				<li><a class="navbar-item" href="https://doc.akka.io/docs/alpakka/current/">Alpakka</a></li>
-				<li><a href="https://doc.akka.io/docs/akka-enhancements/current/akka-resilience-enhancements.html">Akka Resilience Enhancements</a></li>
-				<li><a href="https://doc.akka.io/docs/akka-enhancements/current/akka-persistence-enhancements.html">Akka Persistence Enhancements</a></li>
-				<li><a href="https://cloudflow.io/docs/current/">Cloudflow</a></li>
-				<li><a href="https://developer.lightbend.com/docs/cloudflow/current/">Cloudflow Enterprise Features</a></li>
-				<li><a href="https://developer.lightbend.com/docs/fortify/current/">Fortify SCA for Scala</a></li>		
+				<li><a href="https://developer.lightbend.com/docs/cloudflow/current/">Akka Data Pipelines</a></li>
+				<li><a href="https://docs.cloudstate.com/">Akka Serverless</a></li>
+				<li><a href="https://developer.lightbend.com/docs/fortify/current/">Fortify SCA for Scala</a></li>	
+				<li><a href="https://developer.lightbend.com/docs/console/current/">Lightbend Console</a></li>
+				<li><a href="https://developer.lightbend.com/docs/telemetry/current/home.html">Lightbend Telemetry</a></li>
 		</ul>
 	</section>
 	<section>
+		<h3>Open Source Docs</h3>
 		<ul>
-				<li><a class="navbar-item" href="https://www.lagomframework.com/documentation/">Lagom Framework</a></li>
-				<li><a href="https://developer.lightbend.com/docs/console/current/">Lightbend Console</a></li>
-				<li><a class="navbar-item" href="https://www.playframework.com/documentation">Play Framework</a></li>
-				<li><a class="navbar-item" href="https://www.scala-sbt.org/documentation.html">sbt</a></li>
-				<li><a class="navbar-item" href="https://docs.scala-lang.org/">Scala</a></li>
-				<li><a class="navbar-item" href="http://slick.lightbend.com/doc/3.2.1/">Slick</a></li>
-				<li><a href="https://developer.lightbend.com/docs/telemetry/current/home.html">Lightbend Telemetry</a></li>			
+				<li><a href="https://akka.io/docs/">Akka</a></li>
+        <li><a href="https://doc.akka.io/docs/alpakka/current/">Alpakka</a></li>
+				<li><a href="https://cloudflow.io/docs/current/">Cloudflow</a></li>	
+				<li><a href="https://cloudstate.io/docs/">Cloudstate</a></li>	
+				<li><a href="https://www.scala-sbt.org/1.x/docs/">sbt</a></li>
+				<li><a href="https://docs.scala-lang.org/">Scala</a></li		
+					
 		</ul>
 	</section>
 	<section>

--- a/docs-source/supplemental_ui/partials/footer-nav.hbs
+++ b/docs-source/supplemental_ui/partials/footer-nav.hbs
@@ -17,7 +17,7 @@
 				<li><a href="https://cloudflow.io/docs/current/">Cloudflow</a></li>	
 				<li><a href="https://cloudstate.io/docs/">Cloudstate</a></li>	
 				<li><a href="https://www.scala-sbt.org/1.x/docs/">sbt</a></li>
-				<li><a href="https://docs.scala-lang.org/">Scala</a></li		
+				<li><a href="https://docs.scala-lang.org/">Scala</a></li>
 					
 		</ul>
 	</section>

--- a/docs-source/supplemental_ui/partials/header-content.hbs
+++ b/docs-source/supplemental_ui/partials/header-content.hbs
@@ -56,7 +56,7 @@
                   <a href="https://www.lightbend.com/about-lightbend">Who Is Lightbend?</a>
                   <a href="https://www.lightbend.com/customers">Who Uses Lightbend?</a>
                   <a href="https://www.lightbend.com/lightbend-subscription">Why Get A Subscription?</a>
-                  <a href="https://www.lightbend.com/company/news">News & Press</a>
+                  <a href="https://www.lightbend.com/company/news">News &amp; Press</a>
                   <a href="https://www.lightbend.com/contact">Contact Us</a>
               </section>
             </div>

--- a/docs-source/supplemental_ui/partials/header-content.hbs
+++ b/docs-source/supplemental_ui/partials/header-content.hbs
@@ -14,19 +14,25 @@
       <div id="topbar-nav" class="navbar-menu">
         <div class="navbar-end">
           <div class="navbar-item has-dropdown is-hoverable">
-            <span class="navbar-link">Documentation</span>
+            <span class="navbar-link">Library</span>
             <div class="navbar-dropdown">
               <section>
-                <header>Lightbend</header>
-                <a href="#">Akka Platform Guide</a>
-                <a href="#">Akka Data Pipelines</a>
-                <a href="#">Akka Serverless</a>
+                <header>Lightbend Docs</header>
+                
+                <a href="https://developer.lightbend.com/docs/cloudflow">Akka Data Pipelines</a>
+                <a href="https://docs.cloudstate.com">Akka Serverless</a>
+                <a href="https://developer.lightbend.com/docs/fortify/current/">Fortify SCA for Scala</a>
+                <a href="https://developer.lightbend.com/docs/console/current/index.html">Lightbend Console</a>                
+                <a href="https://developer.lightbend.com/docs/telemetry/current/home.html">Lightbend Telemetry</a>
               </section>
               <section>
-                  <header>Open Source</header>
-                  <a href="#">Akka</a>
-                  <a href="#">Cloudflow</a>
-                  <a href="#">Cloudstate</a>
+                  <header>Open Source Docs</header>
+                  <a href="https://akka.io/docs/" >Akka</a> <br>
+                  <a href="https://doc.akka.io/docs/alpakka/current/">Alpakka</a> <br>
+                  <a href="https://cloudflow.io/docs/current/index.html" >Cloudflow</a>
+                  <a href="https://cloudstate.io/docs/" >Cloudstate</a> <br>
+                  <a href="https://www.scala-sbt.org/1.x/docs/">sbt</a> <br>
+                  <a href="https://docs.scala-lang.org/">Scala</a>
               </section>
             </div>
           </div>
@@ -51,7 +57,7 @@
                   <a href="https://www.lightbend.com/customers">Who Uses Lightbend?</a>
                   <a href="https://www.lightbend.com/lightbend-subscription">Why Get A Subscription?</a>
                   <a href="https://www.lightbend.com/company/news">News & Press</a>
-                  <a href="https://www.lightbend.com/contact">Get In Contact</a>
+                  <a href="https://www.lightbend.com/contact">Contact Us</a>
               </section>
             </div>
           </div>


### PR DESCRIPTION
This changes the menu item from Documentation, which is a bit confusing since the reader is looking at a documentation page to Library, which implies a list of other resources. It also aligns these links along the current LB strategy. @rasummer, for some of the shorter names in the toolbar menu, I had to add a <br> because they would fall on the same line as another entry. I assume you could fix this with css instead? 

@patriknw, do we expect this guide to be versioned? If not, we should change the version number in the antora file to "master", this would prevent the "Snapshot" version selector from appearing at the bottom of the TOC. 
