### PR TITLE
No versioning of the guide

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -203,7 +203,7 @@
 ---------------
 
 Licenses for dependency projects can be found here:
-[http://akka.io/docs/akka/snapshot/project/licenses.html]
+[http://akka.io/docs/akka/current/project/licenses.html]
 
 ---------------
 

--- a/Makefile
+++ b/Makefile
@@ -32,9 +32,9 @@ html: clean docker-image
 		-t ${antora_docker_image}:${antora_docker_image_tag} \
 		--cache-dir=./.cache/antora \
 		docs-source/site.yml
-	@echo "Done file://${target_dir}/snapshot/index.html"
+	@echo "Done ${target_dir}/index.html"
 	@echo "# Tech Hub wants to know what to publish:"
-	@echo "${target_dir}/snapshot/"
+	@echo "${target_dir}"
 
 html-author-mode: clean docker-image
 	mv docs-source/supplemental_ui/partials/head-scripts.hbs docs-source/supplemental_ui/partials/head-scripts.hbs.tmp
@@ -46,7 +46,7 @@ html-author-mode: clean docker-image
 		--cache-dir=./.cache/antora \
 		docs-source/author-mode-site.yml
 	mv docs-source/supplemental_ui/partials/head-scripts.hbs.tmp docs-source/supplemental_ui/partials/head-scripts.hbs
-	@echo "Done file://${target_dir}/snapshot/index.html"
+	@echo "Done ${target_dir}/index.html"
 
 check-links: docker-image
 	docker run \
@@ -64,4 +64,4 @@ list-todos: html docker-image
 		--entrypoint /bin/sh \
 		-t ${antora_docker_image}:${antora_docker_image_tag} \
 		--cache-dir=./.cache/antora \
-		-c 'find /antora/target/snapshot/ -name "*.html" -print0 | xargs -0 grep -iE "TODO|FIXME|REVIEWERS|adoc"'
+		-c 'find /antora/target/ -name "*.html" -print0 | xargs -0 grep -iE "TODO|FIXME|REVIEWERS|adoc"'

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Try it with:
 1. git clone https://github.com/akka/akka-platform-guide
 2. cd akka-platform-guide
 3. make html-author-mode
-4. open target/staging/snapshot/index.html
+4. open target/index.html
 5. read and follow the instructions in the tutorial
 
 Feel free to give your feedback in the form of issues/PRs, or chat in https://gitter.im/akka/dev.

--- a/docs-source/docs/antora.yml
+++ b/docs-source/docs/antora.yml
@@ -1,5 +1,5 @@
 name: "" # root
-version: "snapshot"
+version: "master"
 title: "" # removed title to prevent a double title entry in TOC
 nav:
 - modules/ROOT/nav.adoc

--- a/docs-source/site.yml
+++ b/docs-source/site.yml
@@ -4,16 +4,20 @@ site:
   
 content:
   sources:
-  - url: git@github.com:akka/akka-platform-guide.git
+#  - url: git@github.com:akka/akka-platform-guide.git
+  - url: ./../
     start-paths:
     - docs-source/docs
-    branches: [main]
+#    branches: [main]
+    branches: [HEAD]
+
 
 ui: 
   bundle:
-    url: https://github.com/lightbend/antora-ui-lightbend-theme/raw/master/build/ui-bundle.zip
+    url: https://gitlab.com/antora/antora-ui-default/-/jobs/artifacts/master/raw/build/ui-bundle.zip?job=bundle-stable
     snapshot: true
-    
+  supplemental_files: ./supplemental_ui
+
 runtime:
   fetch: true
 
@@ -26,6 +30,7 @@ asciidoc:
     doc-title: 'Akka Platform Guide'
     # the following turns on next and previous links in the new template
     page-pagination: ""
+    page-toctitle: "On This Page"
 
 output:
   dir: ./../target


### PR DESCRIPTION
Antora uses the magic version name `master` to be used without the version in the URL, which affects the version selector in the lower left corner. Annoying that we can't use "main" here as we do for the main branch.

* update directories to not contain "snapshot"
* Let the default make target will use the local version of the sources and not pull it via git anymore.
* Use the new theme even in `site.yml`

References #297 