### PR TITLE
Fix YAML syntax

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,8 @@ jobs:
   include:
     - stage: test
       script:
-        cd docs-source/docs/modules/microservices-tutorial/examples/shopping-analytics-service-scala
-        sbt -jvm-opts .jvmopts-travis "test; scalafmtCheckAll"
+        - cd docs-source/docs/modules/microservices-tutorial/examples/shopping-analytics-service-scala
+        - sbt -jvm-opts .jvmopts-travis "test; scalafmtCheckAll"
       name: "Shopping analytics service Scala"
     - script:
         - cd docs-source/docs/modules/microservices-tutorial/examples/shopping-analytics-service-java


### PR DESCRIPTION
Without `-` it's all a single command:

```
The command "cd docs-source/docs/modules/microservices-tutorial/examples/shopping-analytics-service-scala sbt -jvm-opts .jvmopts-travis "test; scalafmtCheckAll"" exited with 0.
```

So `sbt -jvm-opts .jvmopts-travis "test; scalafmtCheckAll"` is not really run.
