### PR TITLE
Remove unused argument jvm-opts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ jobs:
     - stage: test
       script:
         - cd docs-source/docs/modules/microservices-tutorial/examples/shopping-analytics-service-scala
-        - sbt -jvm-opts .jvmopts-travis "test; scalafmtCheckAll"
+        - sbt "test; scalafmtCheckAll"
       name: "Shopping analytics service Scala"
     - script:
         - cd docs-source/docs/modules/microservices-tutorial/examples/shopping-analytics-service-java
@@ -27,7 +27,7 @@ jobs:
     - script:
         - cd docs-source/docs/modules/microservices-tutorial/examples/shopping-cart-service-scala
         - docker-compose up -d
-        - sbt -jvm-opts .jvmopts-travis "test; scalafmtCheckAll"
+        - sbt "test; scalafmtCheckAll"
       name: "Shopping cart service Scala"
     - script:
         - cd docs-source/docs/modules/microservices-tutorial/examples/shopping-cart-service-java
@@ -36,7 +36,7 @@ jobs:
       name: "Shopping cart service Java"
     - script:
         - cd docs-source/docs/modules/microservices-tutorial/examples/shopping-order-service-scala
-        - sbt -jvm-opts .jvmopts-travis "test; scalafmtCheckAll"
+        - sbt "test; scalafmtCheckAll"
       name: "Shopping order service Scala"
     - script:
         - cd docs-source/docs/modules/microservices-tutorial/examples/shopping-order-service-java
@@ -46,36 +46,36 @@ jobs:
     - script:
         - cd docs-source/docs/modules/microservices-tutorial/examples/01-shopping-cart-service-scala
         - docker-compose up -d
-        - sbt -jvm-opts .jvmopts-travis "test; scalafmtCheckAll"
+        - sbt "test; scalafmtCheckAll"
       name: "01 Shopping cart service"
     - script:
         - cd docs-source/docs/modules/microservices-tutorial/examples/02-shopping-cart-service-scala
         - docker-compose up -d
-        - sbt -jvm-opts .jvmopts-travis "test; scalafmtCheckAll"
+        - sbt "test; scalafmtCheckAll"
       name: "02 Shopping cart service"
     - script:
         - cd docs-source/docs/modules/microservices-tutorial/examples/03-shopping-cart-service-scala
         - docker-compose up -d
-        - sbt -jvm-opts .jvmopts-travis "test; scalafmtCheckAll"
+        - sbt "test; scalafmtCheckAll"
       name: "03 Shopping cart service"
     - script:
         - cd docs-source/docs/modules/microservices-tutorial/examples/04-shopping-cart-service-scala
         - docker-compose up -d
-        - sbt -jvm-opts .jvmopts-travis "test; scalafmtCheckAll"
+        - sbt "test; scalafmtCheckAll"
       name: "04 Shopping cart service"
     - script:
         - cd docs-source/docs/modules/microservices-tutorial/examples/05-shopping-cart-service-scala
         - docker-compose up -d
-        - sbt -jvm-opts .jvmopts-travis "test; scalafmtCheckAll"
+        - sbt "test; scalafmtCheckAll"
       name: "05 Shopping cart service"
 
     - script:
         - cd docs-source/docs/modules/how-to/examples/shopping-cart-service-scala
-        - sbt -jvm-opts .jvmopts-travis "test; scalafmtCheckAll"
+        - sbt "test; scalafmtCheckAll"
       name: "Howto example code"
     - script:
         - cd docs-source/docs/modules/how-to/examples/cleanup-dependencies-project
-        - sbt -jvm-opts .jvmopts-travis "test; scalafmtCheckAll"
+        - sbt "test; scalafmtCheckAll"
       name: "Howto cleanup dependencies"
 
     - script:


### PR DESCRIPTION
When `cd`-ing into each project, there is no `.jvmopts-travis` file and, still, `sbt` in travis works as expected. I think `sbt-extras` (which is the one provided by TravisCI) doesn't fail when `-jvm-opts` points to a non-existing file.