### PR TITLE
Always drop caches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,16 @@ before_install:
 
 jobs:
   include:
+    - stage: drop-travis-caches
+      script:
+        - rm -rf $HOME/.m2
+        - rm -rf $HOME/.ivy2/cache
+        - rm -rf $HOME/.sbt/boot
+        - rm -rf $HOME/.sbt/launchers
+        - rm -rf $HOME/.cache/coursier
+        - rm -rf $HOME/.jabba
+      name: "drop-travis-caches"
+
     - stage: check-files
       script:
         - scripts/copy-identical-files.sh
@@ -127,6 +137,8 @@ jobs:
       name: "Publish snapshot site"
 
 stages:
+  - name: drop-travis-caches
+
   - name: check-files
     if: NOT tag =~ ^v
 


### PR DESCRIPTION
Introduces an initial stage with a single job that will produce an empty cache. Running this job before attempting a retry of a job will ensure the cache exists but it's empty.

Note that the recent issue we had were a dirty cache in `main` that would propagate to each and every PR. With this change PR builds no longer fallback to the cache in `main`. Also, a dirty cache will only be a build away from reconstructing.