### PR TITLE
use tabset for Maven/sbt in dev-env.adoc and template.adoc, #343

### DIFF
--- a/docs-source/README.adoc
+++ b/docs-source/README.adoc
@@ -35,8 +35,8 @@ To create a new page, start your file with a title and select from the following
 :page-toclevels: 3 //overide number of toc levels, default is 2. To turn off toc at page level set to -1
 
 :!page-supergroup-java-scala: Language //remove '!' to enable tabbed example boxes for scala and java
-:!page-supergroup-sbt-maven: Build Tool //remove '!' to enable tabbed example boxes for sbt and maven
-:!page-supergroup-sbt-maven-gradle: Build Tool  //remove '!' to enable tabbed example boxes for sbt, maven, and gradle
+:!page-supergroup-maven-sbt: Build Tool //remove '!' to enable tabbed example boxes for maven and sbt
+:!page-supergroup-maven-gradle-sbt: Build Tool  //remove '!' to enable tabbed example boxes for maven, gradle and sbt
 :!page-supergroup-minishift-minikube: Platform  //remove '!' to enable tabbed example boxes for Minishift and Minikube
 :!page-supergroup-kubernetes-openshift: Platform //remove '!' to enable tabbed example boxes for Kubernetes and OpenShift
 :!page-supergroup-mac-ubuntu: OS //remove '!' to enable tabbed example boxes for Mac and Ubuntu

--- a/docs-source/docs/modules/microservices-tutorial/pages/dev-env.adoc
+++ b/docs-source/docs/modules/microservices-tutorial/pages/dev-env.adoc
@@ -1,10 +1,14 @@
 = I: Set up your development environment
 :page-supergroup-java-scala: Language
+:page-supergroup-maven-sbt: Build tool
 
 include::ROOT:partial$include.adoc[]
 
+Select your preferred language (Java/Scala) above.
 
 To follow tutorial steps you will need a code editor, a build tool, and `grpcurl` (a CLI for sending gRPC calls). You can use your preferred code editor. We provide the steps for using https://www.jetbrains.com/idea/[IntelliJ IDEA {tab-icon}, window="tab"] from JetBrains. For the [.group-scala]#Scala# [.group-java]#Java# version of the example, we use [.group-scala]#`sbt`# [.group-java]#`Apache Maven`# as the build tool.
+
+Select [.group-scala]#sbt# [.group-java]#Maven# as build tool above.
 
 This tutorial uses Cassandra and Kafka. You may run local installations during development, but we recommend running both services using https://docs.docker.com[Docker {tab-icon}, window="tab"]. The template project's root directory includes a https://docs.docker.com/compose/[Docker Compose] https://docs.docker.com/compose/[{tab-icon}, window="tab"] file that you can use to run Cassandra and Kafka. The provided Docker Compose file also runs Zookeeper which is required to run a Kafka broker.
 
@@ -24,23 +28,31 @@ We also provide downloadable versions of the example at different phases of comp
 :!sectnums:
 == IntelliJ IDEA
 
-[.group-java]
+[.tabset]
+Java::
++
 Download and install https://www.jetbrains.com/idea/download/[IntelliJ {tab-icon}, window="tab"].
 
-[.group-scala]
+Scala::
++
 To install IntelliJ and prepare to develop the Scala example, follow these steps:
 
-[.group-scala]
 . Download and install https://www.jetbrains.com/idea/download/[IntelliJ {tab-icon}, window="tab"].
 . From the *Preferences* menu, add the *Scala* plugin.
 
 
 == Build tool
 
-[.group-scala]
+[.tabset]
+Maven::
++
+For the Java Shopping Cart example, we use `Maven` as the build tool. http://maven.apache.org/install.html[Install Maven] if you haven't already.
+
+sbt::
++
 For the Scala Shopping Cart example, we use `sbt` as the build tool. https://www.scala-sbt.org/download.html[Install sbt] if you haven't already.
 
-[TIP.group-scala]
+[TIP.group-sbt]
 ====
 `sbt` is an interactive shell. If you start it with the `sbt` command, you can repeatedly run tasks like `compile` and `test` in the sbt shell. In the tutorial we use the full command for clarity, such as `sbt compile`. You can run tasks independently in this way, but it's faster to leave the `sbt` shell running and only enter the tasks. For example:
 
@@ -53,9 +65,6 @@ sbt:shopping-cart-service> test
 ...
 ----
 ====
-
-[.group--java]
-For the Java Shopping Cart example, we use `Maven` as the build tool. http://maven.apache.org/install.html[Install Maven] if you haven't already.
 
 == The grpcurl tool
 

--- a/docs-source/docs/modules/microservices-tutorial/pages/dev-env.adoc
+++ b/docs-source/docs/modules/microservices-tutorial/pages/dev-env.adoc
@@ -1,14 +1,11 @@
 = I: Set up your development environment
 :page-supergroup-java-scala: Language
-:page-supergroup-maven-sbt: Build tool
 
 include::ROOT:partial$include.adoc[]
 
 Select your preferred language (Java/Scala) above.
 
 To follow tutorial steps you will need a code editor, a build tool, and `grpcurl` (a CLI for sending gRPC calls). You can use your preferred code editor. We provide the steps for using https://www.jetbrains.com/idea/[IntelliJ IDEA {tab-icon}, window="tab"] from JetBrains. For the [.group-scala]#Scala# [.group-java]#Java# version of the example, we use [.group-scala]#`sbt`# [.group-java]#`Apache Maven`# as the build tool.
-
-Select [.group-scala]#sbt# [.group-java]#Maven# as build tool above.
 
 This tutorial uses Cassandra and Kafka. You may run local installations during development, but we recommend running both services using https://docs.docker.com[Docker {tab-icon}, window="tab"]. The template project's root directory includes a https://docs.docker.com/compose/[Docker Compose] https://docs.docker.com/compose/[{tab-icon}, window="tab"] file that you can use to run Cassandra and Kafka. The provided Docker Compose file also runs Zookeeper which is required to run a Kafka broker.
 
@@ -44,15 +41,15 @@ To install IntelliJ and prepare to develop the Scala example, follow these steps
 == Build tool
 
 [.tabset]
-Maven::
+Java::
 +
 For the Java Shopping Cart example, we use `Maven` as the build tool. http://maven.apache.org/install.html[Install Maven] if you haven't already.
 
-sbt::
+Scala::
 +
 For the Scala Shopping Cart example, we use `sbt` as the build tool. https://www.scala-sbt.org/download.html[Install sbt] if you haven't already.
 
-[TIP.group-sbt]
+[TIP.Scala]
 ====
 `sbt` is an interactive shell. If you start it with the `sbt` command, you can repeatedly run tasks like `compile` and `test` in the sbt shell. In the tutorial we use the full command for clarity, such as `sbt compile`. You can run tasks independently in this way, but it's faster to leave the `sbt` shell running and only enter the tasks. For example:
 

--- a/docs-source/docs/modules/microservices-tutorial/pages/template.adoc
+++ b/docs-source/docs/modules/microservices-tutorial/pages/template.adoc
@@ -1,5 +1,6 @@
 = II: Start a project
 :page-supergroup-java-scala: Language
+:page-supergroup-maven-sbt: Build tool
 
 include::ROOT:partial$include.adoc[]
 
@@ -23,12 +24,15 @@ In the first part of the tutorial we will work with the `shopping-cart-service` 
 
 Change to the new `shopping-cart-service` project directory and try to build it with:
 
-[.group-java]
+[.tabset]
+Maven::
++
 ----
 mvn compile
 ----
 
-[.group-scala]
+sbt::
++
 ----
 sbt compile
 ----

--- a/docs-source/docs/modules/microservices-tutorial/pages/template.adoc
+++ b/docs-source/docs/modules/microservices-tutorial/pages/template.adoc
@@ -1,6 +1,5 @@
 = II: Start a project
 :page-supergroup-java-scala: Language
-:page-supergroup-maven-sbt: Build tool
 
 include::ROOT:partial$include.adoc[]
 
@@ -25,13 +24,13 @@ In the first part of the tutorial we will work with the `shopping-cart-service` 
 Change to the new `shopping-cart-service` project directory and try to build it with:
 
 [.tabset]
-Maven::
+Java::
 +
 ----
 mvn compile
 ----
 
-sbt::
+Scala::
 +
 ----
 sbt compile

--- a/docs-source/supplemental_ui/partials/supergroups.hbs
+++ b/docs-source/supplemental_ui/partials/supergroups.hbs
@@ -10,23 +10,23 @@
 		</span>
 	{{/if}}
 
-	{{#if page.attributes.supergroup-sbt-maven}}
+	{{#if page.attributes.supergroup-maven-sbt}}
 		<span>
-			<label>{{page.attributes.supergroup-sbt-maven}}</label>
-			<select class="supergroup" name="supergroup-sbt-maven">
-				<option class="group" value="group-sbt">sbt</option>
+			<label>{{page.attributes.supergroup-maven-sbt}}</label>
+			<select class="supergroup" name="supergroup-maven-sbt">
 				<option class="group" value="group-maven">Maven</option>
+				<option class="group" value="group-sbt">sbt</option>
 			</select>
 		</span>
 	{{/if}}
 
-	{{#if page.attributes.supergroup-sbt-maven-gradle}}
+	{{#if page.attributes.supergroup-maven-gradle-sbt}}
 		<span>
-			<label>{{page.attributes.supergroup-sbt-maven-gradle}}</label>
-			<select class="supergroup" name="supergroup-sbt-maven-gradle">
-				<option class="group" value="group-sbt">sbt</option>
+			<label>{{page.attributes.supergroup-maven-gradle-sbt}}</label>
+			<select class="supergroup" name="supergroup-maven-gradle-sbt">
 				<option class="group" value="group-maven">Maven</option>
 				<option class="group" value="group-gradle">Gradle</option>
+				<option class="group" value="group-sbt">sbt</option>
 			</select>
 		</span>
 	{{/if}}


### PR DESCRIPTION
* because there hasn't been any source code choice yet it could be easy to miss
  the language choice
* leaving later sbt/mvn snippets as is, but when/if we add gradle we will probably
  use tabs in all places

References #343

If trying this you should use `make local-preview` instead of opening the files in browser.
