### PR TITLE
add .gitignore to all samples

### DIFF
--- a/docs-source/docs/modules/microservices-tutorial/examples/00-shopping-analytics-service-java/.gitignore
+++ b/docs-source/docs/modules/microservices-tutorial/examples/00-shopping-analytics-service-java/.gitignore
@@ -1,0 +1,10 @@
+target/
+
+.settings
+.project
+.classpath
+
+.idea
+*.iml
+
+.DS_Store

--- a/docs-source/docs/modules/microservices-tutorial/examples/00-shopping-analytics-service-scala/.gitignore
+++ b/docs-source/docs/modules/microservices-tutorial/examples/00-shopping-analytics-service-scala/.gitignore
@@ -1,0 +1,10 @@
+target/
+
+.settings
+.project
+.classpath
+
+.idea
+*.iml
+
+.DS_Store

--- a/docs-source/docs/modules/microservices-tutorial/examples/00-shopping-cart-service-java/.gitignore
+++ b/docs-source/docs/modules/microservices-tutorial/examples/00-shopping-cart-service-java/.gitignore
@@ -1,0 +1,10 @@
+target/
+
+.settings
+.project
+.classpath
+
+.idea
+*.iml
+
+.DS_Store

--- a/docs-source/docs/modules/microservices-tutorial/examples/00-shopping-cart-service-scala/.gitignore
+++ b/docs-source/docs/modules/microservices-tutorial/examples/00-shopping-cart-service-scala/.gitignore
@@ -1,0 +1,10 @@
+target/
+
+.settings
+.project
+.classpath
+
+.idea
+*.iml
+
+.DS_Store

--- a/docs-source/docs/modules/microservices-tutorial/examples/00-shopping-order-service-java/.gitignore
+++ b/docs-source/docs/modules/microservices-tutorial/examples/00-shopping-order-service-java/.gitignore
@@ -1,0 +1,10 @@
+target/
+
+.settings
+.project
+.classpath
+
+.idea
+*.iml
+
+.DS_Store

--- a/docs-source/docs/modules/microservices-tutorial/examples/00-shopping-order-service-scala/.gitignore
+++ b/docs-source/docs/modules/microservices-tutorial/examples/00-shopping-order-service-scala/.gitignore
@@ -1,0 +1,10 @@
+target/
+
+.settings
+.project
+.classpath
+
+.idea
+*.iml
+
+.DS_Store

--- a/docs-source/docs/modules/microservices-tutorial/examples/01-shopping-cart-service-java/.gitignore
+++ b/docs-source/docs/modules/microservices-tutorial/examples/01-shopping-cart-service-java/.gitignore
@@ -1,0 +1,10 @@
+target/
+
+.settings
+.project
+.classpath
+
+.idea
+*.iml
+
+.DS_Store

--- a/docs-source/docs/modules/microservices-tutorial/examples/01-shopping-cart-service-scala/.gitignore
+++ b/docs-source/docs/modules/microservices-tutorial/examples/01-shopping-cart-service-scala/.gitignore
@@ -1,0 +1,10 @@
+target/
+
+.settings
+.project
+.classpath
+
+.idea
+*.iml
+
+.DS_Store

--- a/docs-source/docs/modules/microservices-tutorial/examples/02-shopping-cart-service-java/.gitignore
+++ b/docs-source/docs/modules/microservices-tutorial/examples/02-shopping-cart-service-java/.gitignore
@@ -1,0 +1,10 @@
+target/
+
+.settings
+.project
+.classpath
+
+.idea
+*.iml
+
+.DS_Store

--- a/docs-source/docs/modules/microservices-tutorial/examples/02-shopping-cart-service-scala/.gitignore
+++ b/docs-source/docs/modules/microservices-tutorial/examples/02-shopping-cart-service-scala/.gitignore
@@ -1,0 +1,10 @@
+target/
+
+.settings
+.project
+.classpath
+
+.idea
+*.iml
+
+.DS_Store

--- a/docs-source/docs/modules/microservices-tutorial/examples/03-shopping-cart-service-java/.gitignore
+++ b/docs-source/docs/modules/microservices-tutorial/examples/03-shopping-cart-service-java/.gitignore
@@ -1,0 +1,10 @@
+target/
+
+.settings
+.project
+.classpath
+
+.idea
+*.iml
+
+.DS_Store

--- a/docs-source/docs/modules/microservices-tutorial/examples/03-shopping-cart-service-scala/.gitignore
+++ b/docs-source/docs/modules/microservices-tutorial/examples/03-shopping-cart-service-scala/.gitignore
@@ -1,0 +1,10 @@
+target/
+
+.settings
+.project
+.classpath
+
+.idea
+*.iml
+
+.DS_Store

--- a/docs-source/docs/modules/microservices-tutorial/examples/04-shopping-cart-service-java/.gitignore
+++ b/docs-source/docs/modules/microservices-tutorial/examples/04-shopping-cart-service-java/.gitignore
@@ -1,0 +1,10 @@
+target/
+
+.settings
+.project
+.classpath
+
+.idea
+*.iml
+
+.DS_Store

--- a/docs-source/docs/modules/microservices-tutorial/examples/04-shopping-cart-service-scala/.gitignore
+++ b/docs-source/docs/modules/microservices-tutorial/examples/04-shopping-cart-service-scala/.gitignore
@@ -1,0 +1,10 @@
+target/
+
+.settings
+.project
+.classpath
+
+.idea
+*.iml
+
+.DS_Store

--- a/docs-source/docs/modules/microservices-tutorial/examples/05-shopping-cart-service-java/.gitignore
+++ b/docs-source/docs/modules/microservices-tutorial/examples/05-shopping-cart-service-java/.gitignore
@@ -1,0 +1,10 @@
+target/
+
+.settings
+.project
+.classpath
+
+.idea
+*.iml
+
+.DS_Store

--- a/docs-source/docs/modules/microservices-tutorial/examples/05-shopping-cart-service-scala/.gitignore
+++ b/docs-source/docs/modules/microservices-tutorial/examples/05-shopping-cart-service-scala/.gitignore
@@ -1,0 +1,10 @@
+target/
+
+.settings
+.project
+.classpath
+
+.idea
+*.iml
+
+.DS_Store

--- a/docs-source/docs/modules/microservices-tutorial/examples/shopping-analytics-service-java/.gitignore
+++ b/docs-source/docs/modules/microservices-tutorial/examples/shopping-analytics-service-java/.gitignore
@@ -1,0 +1,10 @@
+target/
+
+.settings
+.project
+.classpath
+
+.idea
+*.iml
+
+.DS_Store

--- a/docs-source/docs/modules/microservices-tutorial/examples/shopping-analytics-service-scala/.gitignore
+++ b/docs-source/docs/modules/microservices-tutorial/examples/shopping-analytics-service-scala/.gitignore
@@ -1,0 +1,10 @@
+target/
+
+.settings
+.project
+.classpath
+
+.idea
+*.iml
+
+.DS_Store

--- a/docs-source/docs/modules/microservices-tutorial/examples/shopping-cart-service-java/.gitignore
+++ b/docs-source/docs/modules/microservices-tutorial/examples/shopping-cart-service-java/.gitignore
@@ -1,0 +1,10 @@
+target/
+
+.settings
+.project
+.classpath
+
+.idea
+*.iml
+
+.DS_Store

--- a/docs-source/docs/modules/microservices-tutorial/examples/shopping-cart-service-scala/.gitignore
+++ b/docs-source/docs/modules/microservices-tutorial/examples/shopping-cart-service-scala/.gitignore
@@ -1,0 +1,10 @@
+target/
+
+.settings
+.project
+.classpath
+
+.idea
+*.iml
+
+.DS_Store

--- a/docs-source/docs/modules/microservices-tutorial/examples/shopping-order-service-java/.gitignore
+++ b/docs-source/docs/modules/microservices-tutorial/examples/shopping-order-service-java/.gitignore
@@ -1,0 +1,10 @@
+target/
+
+.settings
+.project
+.classpath
+
+.idea
+*.iml
+
+.DS_Store

--- a/docs-source/docs/modules/microservices-tutorial/examples/shopping-order-service-scala/.gitignore
+++ b/docs-source/docs/modules/microservices-tutorial/examples/shopping-order-service-scala/.gitignore
@@ -1,0 +1,10 @@
+target/
+
+.settings
+.project
+.classpath
+
+.idea
+*.iml
+
+.DS_Store

--- a/scripts/copy-identical-files.sh
+++ b/scripts/copy-identical-files.sh
@@ -118,6 +118,29 @@ cp ${SRC} ${tutorial_root}/shopping-cart-service-java/
 cp ${SRC} ${tutorial_root}/shopping-analytics-service-java/
 cp ${SRC} ${tutorial_root}/shopping-order-service-java/
 
+declare SRC="${tutorial_root}/00-shopping-cart-service-scala/.gitignore"
+cp ${SRC} ${tutorial_root}/01-shopping-cart-service-scala/
+cp ${SRC} ${tutorial_root}/02-shopping-cart-service-scala/
+cp ${SRC} ${tutorial_root}/03-shopping-cart-service-scala/
+cp ${SRC} ${tutorial_root}/04-shopping-cart-service-scala/
+cp ${SRC} ${tutorial_root}/05-shopping-cart-service-scala/
+cp ${SRC} ${tutorial_root}/shopping-cart-service-scala/
+cp ${SRC} ${tutorial_root}/00-shopping-analytics-service-scala/
+cp ${SRC} ${tutorial_root}/shopping-analytics-service-scala/
+cp ${SRC} ${tutorial_root}/00-shopping-order-service-scala/
+cp ${SRC} ${tutorial_root}/shopping-order-service-scala/
+
+cp ${SRC} ${tutorial_root}/01-shopping-cart-service-java/
+cp ${SRC} ${tutorial_root}/02-shopping-cart-service-java/
+cp ${SRC} ${tutorial_root}/03-shopping-cart-service-java/
+cp ${SRC} ${tutorial_root}/04-shopping-cart-service-java/
+cp ${SRC} ${tutorial_root}/05-shopping-cart-service-java/
+cp ${SRC} ${tutorial_root}/shopping-cart-service-java/
+cp ${SRC} ${tutorial_root}/00-shopping-analytics-service-java/
+cp ${SRC} ${tutorial_root}/shopping-analytics-service-java/
+cp ${SRC} ${tutorial_root}/00-shopping-order-service-java/
+cp ${SRC} ${tutorial_root}/shopping-order-service-java/
+
 
 declare SRC="${tutorial_root}/00-shopping-cart-service-scala/ddl-scripts/create_tables.cql"
 cp ${SRC} ${tutorial_root}/01-shopping-cart-service-scala/ddl-scripts/


### PR DESCRIPTION
The original template had a .gitignore file that so how didn't propagated to the templates we created here. 

Minor thing, but quite useful when going through all the tutorial steps.