### PR TITLE
Download sources inside language tabs

### DIFF
--- a/docs-source/docs/modules/microservices-tutorial/pages/complete-entity.adoc
+++ b/docs-source/docs/modules/microservices-tutorial/pages/complete-entity.adoc
@@ -9,11 +9,23 @@ On this page you will learn how to:
 
 * implement an Event Sourced entity by expanding the xref:entity.adoc[previous step]
 
+[.tabset]
+Java::
++
 .Source downloads:
 ****
-* [.group-scala]#link:_attachments/2-shopping-cart-event-sourced-scala.zip[Source]# [.group-java]#link:_attachments/2-shopping-cart-event-sourced-java.zip[Source]# that includes all previous tutorial steps and allows you to start with the steps on this page.
-* [.group-scala]#link:_attachments/3-shopping-cart-event-sourced-complete-scala.zip[Source]# [.group-java]#link:_attachments/3-shopping-cart-event-sourced-complete-java.zip[Source]# with the steps on this page completed.
+* link:_attachments/2-shopping-cart-event-sourced-java.zip[Source] that includes all previous tutorial steps and allows you to start with the steps on this page.
+* link:_attachments/3-shopping-cart-event-sourced-complete-java.zip[Source] with the steps on this page completed.
 ****
+
+Scala::
++
+.Source downloads:
+****
+* link:_attachments/2-shopping-cart-event-sourced-scala.zip[Source] that includes all previous tutorial steps and allows you to start with the steps on this page.
+* link:_attachments/3-shopping-cart-event-sourced-complete-scala.zip[Source] with the steps on this page completed.
+****
+
 
 == More commands and events
 
@@ -308,7 +320,7 @@ Scala::
 include::example$03-shopping-cart-service-scala/src/main/scala/shopping/cart/ShoppingCartServiceImpl.scala[tag=checkoutAndGet]
 ----
 
-As mentioned at the beginning of this page, `RemoveItem` and `AdjustItemQuantity` commands are not mandatory for the subsequent steps of the tutorial. A zip file with the completed for this page implementing the optional commands is available for [.group-scala]#link:_attachments/3-shopping-cart-event-sourced-complete-scala.zip[download]# [.group-java]#link:_attachments/3-shopping-cart-event-sourced-complete-java.zip[download]#.
+As mentioned at the beginning of this page, `RemoveItem` and `AdjustItemQuantity` commands are not mandatory for the subsequent steps of the tutorial. A zip file with the completed steps on this page and implementing the optional commands is available for download (link:_attachments/3-shopping-cart-event-sourced-complete-java.zip[java sources]/link:_attachments/3-shopping-cart-event-sourced-complete-scala.zip[scala sources]).
 
 == Run locally
 

--- a/docs-source/docs/modules/microservices-tutorial/pages/entity.adoc
+++ b/docs-source/docs/modules/microservices-tutorial/pages/entity.adoc
@@ -19,11 +19,23 @@ ifdef::review[REVIEWERS: re: bullet 3 above, the Initialization section only con
 
 If you are unfamiliar with Event Sourcing, refer to the xref:concepts:event-sourcing.adoc[Event Sourcing] section for an explanation.
 
+[.tabset]
+Java::
++
 .Source downloads:
 ****
-* [.group-scala]#link:_attachments/1-shopping-cart-grpc-scala.zip[Source]# [.group-java]#link:_attachments/1-shopping-cart-grpc-java.zip[Source]# that includes all previous tutorial steps and allows you to start with the steps on this page.
-* [.group-scala]#link:_attachments/2-shopping-cart-event-sourced-scala.zip[Source]# [.group-java]#link:_attachments/2-shopping-cart-event-sourced-java.zip[Source]# with the steps on this page completed.
+* link:_attachments/1-shopping-cart-grpc-java.zip[Source] that includes all previous tutorial steps and allows you to start with the steps on this page.
+* link:_attachments/2-shopping-cart-event-sourced-java.zip[Source] with the steps on this page completed.
 ****
+
+Scala::
++
+.Source downloads:
+****
+* link:_attachments/1-shopping-cart-grpc-scala.zip[Source] that includes all previous tutorial steps and allows you to start with the steps on this page.
+* link:_attachments/2-shopping-cart-event-sourced-scala.zip[Source] with the steps on this page completed.
+****
+
 
 :sectnums:
 == Commands and events

--- a/docs-source/docs/modules/microservices-tutorial/pages/grpc-service.adoc
+++ b/docs-source/docs/modules/microservices-tutorial/pages/grpc-service.adoc
@@ -15,11 +15,24 @@ First, we will create the `ShoppingCartService` with a single operation that add
 * interact with the service from the command line
 * deploy to the cloud
 
+
+[.tabset]
+Java::
++
 .Source downloads:
 ****
-* [.group-scala]#link:_attachments/0-shopping-cart-start-scala.zip[Source]# [.group-java]#link:_attachments/0-shopping-cart-start-java.zip[Source]# with the initial project template.
-* [.group-scala]#link:_attachments/1-shopping-cart-grpc-scala.zip[Source]# [.group-java]#link:_attachments/1-shopping-cart-grpc-java.zip[Source]#  with the steps on this page completed.
+* link:_attachments/0-shopping-cart-start-java.zip[Source] with the initial project template.
+* link:_attachments/1-shopping-cart-grpc-java.zip[Source] with the steps on this page completed.
 ****
+
+Scala::
++
+.Source downloads:
+****
+* link:_attachments/0-shopping-cart-start-scala.zip[Source] with the initial project template.
+* link:_attachments/1-shopping-cart-grpc-scala.zip[Source] with the steps on this page completed.
+****
+
 
 
 :sectnums:

--- a/docs-source/docs/modules/microservices-tutorial/pages/projection-grpc-client.adoc
+++ b/docs-source/docs/modules/microservices-tutorial/pages/projection-grpc-client.adoc
@@ -15,11 +15,23 @@ On this page you will learn how to:
 
 ifdef::todo[TODO link to synchronous communication concepts]
 
+[.tabset]
+Java::
++
 .Source downloads:
 ****
-* [.group-scala]#link:_attachments/5-shopping-cart-projection-kafka-scala.zip[Source]# [.group-java]#link:_attachments/5-shopping-cart-projection-kafka-java.zip[Source]# that includes all previous tutorial steps and allows you to start with the steps on this page.
-* [.group-scala]#link:_attachments/6-shopping-cart-complete-scala.zip[Source]# [.group-java]#link:_attachments/6-shopping-cart-complete-java.zip[Source]# with the steps on this page completed.
+* link:_attachments/5-shopping-cart-projection-kafka-java.zip[Source] that includes all previous tutorial steps and allows you to start with the steps on this page.
+* link:_attachments/6-shopping-cart-complete-java.zip[Source] with the steps on this page completed.
 ****
+
+Scala::
++
+.Source downloads:
+****
+* link:_attachments/5-shopping-cart-projection-kafka-scala.zip[Source] that includes all previous tutorial steps and allows you to start with the steps on this page.
+* link:_attachments/6-shopping-cart-complete-scala.zip[Source] with the steps on this page completed.
+****
+
 
 == Another gRPC service
 

--- a/docs-source/docs/modules/microservices-tutorial/pages/projection-kafka.adoc
+++ b/docs-source/docs/modules/microservices-tutorial/pages/projection-kafka.adoc
@@ -16,10 +16,21 @@ On this page you will learn how to:
 
 ifdef::todo[TODO link to asynchronous communication concepts]
 
+[.tabset]
+Java::
++
 .Source downloads:
 ****
-* [.group-scala]#link:_attachments/4-shopping-cart-projection-scala.zip[Source]# [.group-java]#link:_attachments/4-shopping-cart-projection-java.zip[Source]# that includes all previous tutorial steps and allows you to start with the steps on this page.
-* [.group-scala]#link:_attachments/5-shopping-cart-projection-kafka-scala.zip[Source]# [.group-java]#link:_attachments/5-shopping-cart-projection-kafka-java.zip[Source]# with the steps on this page completed.
+* link:_attachments/4-shopping-cart-projection-java.zip[Source] that includes all previous tutorial steps and allows you to start with the steps on this page.
+* link:_attachments/5-shopping-cart-projection-kafka-java.zip[Source] with the steps on this page completed.
+****
+
+Scala::
++
+.Source downloads:
+****
+* link:_attachments/4-shopping-cart-projection-scala.zip[Source] that includes all previous tutorial steps and allows you to start with the steps on this page.
+* link:_attachments/5-shopping-cart-projection-kafka-scala.zip[Source] with the steps on this page completed.
 ****
 
 == External representation of the events

--- a/docs-source/docs/modules/microservices-tutorial/pages/projection-query.adoc
+++ b/docs-source/docs/modules/microservices-tutorial/pages/projection-query.adoc
@@ -17,6 +17,24 @@ On this page you will learn how to:
 
 Read the xref:concepts:cqrs.adoc[CQRS] section as a background to why it is good to build a query representation from the events of the entities with a Projection.
 
+
+[.tabset]
+Java::
++
+.Source downloads:
+****
+* link:_attachments/3-shopping-cart-event-sourced-complete-java.zip[Source] that includes all previous tutorial steps and allows you to start with the steps on this page.
+* link:_attachments/4-shopping-cart-projection-java.zip[Source] with the steps on this page completed.
+****
+
+Scala::
++
+.Source downloads:
+****
+* link:_attachments/3-shopping-cart-event-sourced-complete-scala.zip[Source] that includes all previous tutorial steps and allows you to start with the steps on this page.
+* link:_attachments/4-shopping-cart-projection-scala.zip[Source] with the steps on this page completed.
+****
+
 .Source downloads:
 ****
 * [.group-scala]#link:_attachments/3-shopping-cart-event-sourced-complete-scala.zip[Source]# [.group-java]#link:_attachments/3-shopping-cart-event-sourced-complete-java.zip[Source]# that includes all previous tutorial steps and allows you to start with the steps on this page.

--- a/docs-source/docs/modules/microservices-tutorial/pages/template.adoc
+++ b/docs-source/docs/modules/microservices-tutorial/pages/template.adoc
@@ -11,7 +11,7 @@ We provide a template so that you don't need to create the shopping cart project
 == Download the empty template
 [#seed-template]
 
-The starting template is available as downloadable [.group-scala]#link:_attachments/0-shopping-cart-start-scala.zip[zip file]# [.group-java]#link:_attachments/0-shopping-cart-start-java.zip[zip file]#.
+The starting template is available as downloadable zip file (link:_attachments/0-shopping-cart-start-java.zip[java sources]/link:_attachments/0-shopping-cart-start-scala.zip[scala sources]).
 
 Unzip the file and you should have 3 directories:
 


### PR DESCRIPTION
This is how it looks like: 

Simple link to the two zips when we don't have a block. 

![CleanShot 2020-10-22 at 17 44 37](https://user-images.githubusercontent.com/502982/96902074-56dd6f80-1494-11eb-8d28-0c395c885356.png)

**Download sources** inside tabs so user can immediately see that there are two options. 

![CleanShot 2020-10-22 at 17 52 12](https://user-images.githubusercontent.com/502982/96902148-71174d80-1494-11eb-9f7d-77f52ab78092.png)

