### PR TITLE
let ShoppingCartServer take ShoppingCartService param

### DIFF
--- a/docs-source/docs/modules/microservices-tutorial/examples/01-shopping-cart-service-java/src/main/java/shopping/cart/Main.java
+++ b/docs-source/docs/modules/microservices-tutorial/examples/01-shopping-cart-service-java/src/main/java/shopping/cart/Main.java
@@ -30,7 +30,8 @@ public class Main extends AbstractBehavior<Void> {
     String grpcInterface =
         system.settings().config().getString("shopping-cart-service.grpc.interface");
     int grpcPort = system.settings().config().getInt("shopping-cart-service.grpc.port");
-    ShoppingCartServer.start(grpcInterface, grpcPort, system); // <3>
+    ShoppingCartServiceImpl grpcService = new ShoppingCartServiceImpl();
+    ShoppingCartServer.start(grpcInterface, grpcPort, system, grpcService); // <3>
   }
 
   @Override

--- a/docs-source/docs/modules/microservices-tutorial/examples/01-shopping-cart-service-java/src/main/java/shopping/cart/ShoppingCartServer.java
+++ b/docs-source/docs/modules/microservices-tutorial/examples/01-shopping-cart-service-java/src/main/java/shopping/cart/ShoppingCartServer.java
@@ -19,12 +19,11 @@ public final class ShoppingCartServer {
 
   private ShoppingCartServer() {}
 
-  static void start(String host, int port, ActorSystem<?> system) {
-    ShoppingCartServiceImpl impl = new ShoppingCartServiceImpl();
+  static void start(String host, int port, ActorSystem<?> system, ShoppingCartService grpcService) {
     @SuppressWarnings("unchecked")
     Function<HttpRequest, CompletionStage<HttpResponse>> service =
         ServiceHandler.concatOrNotFound(
-            ShoppingCartServiceHandlerFactory.create(impl, system),
+            ShoppingCartServiceHandlerFactory.create(grpcService, system),
             // ServerReflection enabled to support grpcurl without import-path and proto parameters
             ServerReflection.create( // <1>
                 Collections.singletonList(ShoppingCartService.description), system));

--- a/docs-source/docs/modules/microservices-tutorial/examples/01-shopping-cart-service-scala/src/main/scala/shopping/cart/Main.scala
+++ b/docs-source/docs/modules/microservices-tutorial/examples/01-shopping-cart-service-scala/src/main/scala/shopping/cart/Main.scala
@@ -33,10 +33,12 @@ class Main(context: ActorContext[Nothing])
     .getString("shopping-cart-service.grpc.interface")
   val grpcPort = system.settings.config
     .getInt("shopping-cart-service.grpc.port")
+  val grpcService = new ShoppingCartServiceImpl(system)
   ShoppingCartServer.start(
     grpcInterface,
     grpcPort,
-    system
+    system,
+    grpcService
   ) // <3>
 
   override def onMessage(

--- a/docs-source/docs/modules/microservices-tutorial/examples/01-shopping-cart-service-scala/src/main/scala/shopping/cart/Main.scala
+++ b/docs-source/docs/modules/microservices-tutorial/examples/01-shopping-cart-service-scala/src/main/scala/shopping/cart/Main.scala
@@ -33,7 +33,7 @@ class Main(context: ActorContext[Nothing])
     .getString("shopping-cart-service.grpc.interface")
   val grpcPort = system.settings.config
     .getInt("shopping-cart-service.grpc.port")
-  val grpcService = new ShoppingCartServiceImpl(system)
+  val grpcService = new ShoppingCartServiceImpl
   ShoppingCartServer.start(
     grpcInterface,
     grpcPort,

--- a/docs-source/docs/modules/microservices-tutorial/examples/01-shopping-cart-service-scala/src/main/scala/shopping/cart/ShoppingCartServer.scala
+++ b/docs-source/docs/modules/microservices-tutorial/examples/01-shopping-cart-service-scala/src/main/scala/shopping/cart/ShoppingCartServer.scala
@@ -18,7 +18,8 @@ object ShoppingCartServer {
   def start(
       interface: String,
       port: Int,
-      system: ActorSystem[_]): Unit = {
+      system: ActorSystem[_],
+      grpcService: proto.ShoppingCartService): Unit = {
     implicit val sys: ActorSystem[_] = system
     implicit val ec: ExecutionContext =
       system.executionContext
@@ -26,7 +27,7 @@ object ShoppingCartServer {
     val service: HttpRequest => Future[HttpResponse] =
       ServiceHandler.concatOrNotFound(
         proto.ShoppingCartServiceHandler.partial(
-          new ShoppingCartServiceImpl),
+          grpcService),
         // ServerReflection enabled to support grpcurl without import-path and proto parameters
         ServerReflection.partial(
           List(proto.ShoppingCartService)

--- a/docs-source/docs/modules/microservices-tutorial/examples/02-shopping-cart-service-java/src/main/java/shopping/cart/Main.java
+++ b/docs-source/docs/modules/microservices-tutorial/examples/02-shopping-cart-service-java/src/main/java/shopping/cart/Main.java
@@ -34,7 +34,8 @@ public class Main extends AbstractBehavior<Void> {
     String grpcInterface =
         system.settings().config().getString("shopping-cart-service.grpc.interface");
     int grpcPort = system.settings().config().getInt("shopping-cart-service.grpc.port");
-    ShoppingCartServer.start(grpcInterface, grpcPort, system);
+    ShoppingCartServiceImpl grpcService = new ShoppingCartServiceImpl(system);
+    ShoppingCartServer.start(grpcInterface, grpcPort, system, grpcService);
   }
 
   @Override

--- a/docs-source/docs/modules/microservices-tutorial/examples/02-shopping-cart-service-java/src/main/java/shopping/cart/ShoppingCartServer.java
+++ b/docs-source/docs/modules/microservices-tutorial/examples/02-shopping-cart-service-java/src/main/java/shopping/cart/ShoppingCartServer.java
@@ -19,21 +19,20 @@ public final class ShoppingCartServer {
 
   private ShoppingCartServer() {}
 
-  static void start(String host, int port, ActorSystem<?> system) {
-    ShoppingCartServiceImpl impl = new ShoppingCartServiceImpl(system);
+  static void start(String host, int port, ActorSystem<?> system, ShoppingCartService grpcService) {
     @SuppressWarnings("unchecked")
     Function<HttpRequest, CompletionStage<HttpResponse>> service =
         ServiceHandler.concatOrNotFound(
-            ShoppingCartServiceHandlerFactory.create(impl, system),
+            ShoppingCartServiceHandlerFactory.create(grpcService, system),
             // ServerReflection enabled to support grpcurl without import-path and proto parameters
-            ServerReflection.create(
+            ServerReflection.create( // <1>
                 Collections.singletonList(ShoppingCartService.description), system));
 
     CompletionStage<ServerBinding> bound =
-        Http.get(system).newServerAt(host, port).bind(service::apply);
+        Http.get(system).newServerAt(host, port).bind(service::apply); // <2>
 
     bound.whenComplete(
-        (binding, ex) -> {
+        (binding, ex) -> { // <3>
           if (binding != null) {
             binding.addToCoordinatedShutdown(Duration.ofSeconds(3), system);
             InetSocketAddress address = binding.localAddress();

--- a/docs-source/docs/modules/microservices-tutorial/examples/02-shopping-cart-service-scala/src/main/scala/shopping/cart/Main.scala
+++ b/docs-source/docs/modules/microservices-tutorial/examples/02-shopping-cart-service-scala/src/main/scala/shopping/cart/Main.scala
@@ -35,7 +35,8 @@ class Main(context: ActorContext[Nothing])
       .getString("shopping-cart-service.grpc.interface")
   val grpcPort = system.settings.config
     .getInt("shopping-cart-service.grpc.port")
-  ShoppingCartServer.start(grpcInterface, grpcPort, system)
+  val grpcService = new ShoppingCartServiceImpl(system)
+  ShoppingCartServer.start(grpcInterface, grpcPort, system, grpcService)
 
   override def onMessage(msg: Nothing): Behavior[Nothing] =
     this

--- a/docs-source/docs/modules/microservices-tutorial/examples/02-shopping-cart-service-scala/src/main/scala/shopping/cart/Main.scala
+++ b/docs-source/docs/modules/microservices-tutorial/examples/02-shopping-cart-service-scala/src/main/scala/shopping/cart/Main.scala
@@ -36,7 +36,11 @@ class Main(context: ActorContext[Nothing])
   val grpcPort = system.settings.config
     .getInt("shopping-cart-service.grpc.port")
   val grpcService = new ShoppingCartServiceImpl(system)
-  ShoppingCartServer.start(grpcInterface, grpcPort, system, grpcService)
+  ShoppingCartServer.start(
+    grpcInterface,
+    grpcPort,
+    system,
+    grpcService)
 
   override def onMessage(msg: Nothing): Behavior[Nothing] =
     this

--- a/docs-source/docs/modules/microservices-tutorial/examples/03-shopping-cart-service-java/src/main/java/shopping/cart/Main.java
+++ b/docs-source/docs/modules/microservices-tutorial/examples/03-shopping-cart-service-java/src/main/java/shopping/cart/Main.java
@@ -32,7 +32,8 @@ public class Main extends AbstractBehavior<Void> {
     String grpcInterface =
         system.settings().config().getString("shopping-cart-service.grpc.interface");
     int grpcPort = system.settings().config().getInt("shopping-cart-service.grpc.port");
-    ShoppingCartServer.start(grpcInterface, grpcPort, system);
+    ShoppingCartServiceImpl grpcService = new ShoppingCartServiceImpl(system);
+    ShoppingCartServer.start(grpcInterface, grpcPort, system, grpcService);
   }
 
   @Override

--- a/docs-source/docs/modules/microservices-tutorial/examples/03-shopping-cart-service-java/src/main/java/shopping/cart/ShoppingCartServer.java
+++ b/docs-source/docs/modules/microservices-tutorial/examples/03-shopping-cart-service-java/src/main/java/shopping/cart/ShoppingCartServer.java
@@ -19,21 +19,20 @@ public final class ShoppingCartServer {
 
   private ShoppingCartServer() {}
 
-  static void start(String host, int port, ActorSystem<?> system) {
-    ShoppingCartServiceImpl impl = new ShoppingCartServiceImpl(system);
+  static void start(String host, int port, ActorSystem<?> system, ShoppingCartService grpcService) {
     @SuppressWarnings("unchecked")
     Function<HttpRequest, CompletionStage<HttpResponse>> service =
         ServiceHandler.concatOrNotFound(
-            ShoppingCartServiceHandlerFactory.create(impl, system),
+            ShoppingCartServiceHandlerFactory.create(grpcService, system),
             // ServerReflection enabled to support grpcurl without import-path and proto parameters
-            ServerReflection.create(
+            ServerReflection.create( // <1>
                 Collections.singletonList(ShoppingCartService.description), system));
 
     CompletionStage<ServerBinding> bound =
-        Http.get(system).newServerAt(host, port).bind(service::apply);
+        Http.get(system).newServerAt(host, port).bind(service::apply); // <2>
 
     bound.whenComplete(
-        (binding, ex) -> {
+        (binding, ex) -> { // <3>
           if (binding != null) {
             binding.addToCoordinatedShutdown(Duration.ofSeconds(3), system);
             InetSocketAddress address = binding.localAddress();

--- a/docs-source/docs/modules/microservices-tutorial/examples/03-shopping-cart-service-scala/src/main/scala/shopping/cart/Main.scala
+++ b/docs-source/docs/modules/microservices-tutorial/examples/03-shopping-cart-service-scala/src/main/scala/shopping/cart/Main.scala
@@ -33,7 +33,8 @@ class Main(context: ActorContext[Nothing])
       .getString("shopping-cart-service.grpc.interface")
   val grpcPort = system.settings.config
     .getInt("shopping-cart-service.grpc.port")
-  ShoppingCartServer.start(grpcInterface, grpcPort, system)
+  val grpcService = new ShoppingCartServiceImpl(system)
+  ShoppingCartServer.start(grpcInterface, grpcPort, system, grpcService)
 
   override def onMessage(msg: Nothing): Behavior[Nothing] =
     this

--- a/docs-source/docs/modules/microservices-tutorial/examples/03-shopping-cart-service-scala/src/main/scala/shopping/cart/Main.scala
+++ b/docs-source/docs/modules/microservices-tutorial/examples/03-shopping-cart-service-scala/src/main/scala/shopping/cart/Main.scala
@@ -34,7 +34,11 @@ class Main(context: ActorContext[Nothing])
   val grpcPort = system.settings.config
     .getInt("shopping-cart-service.grpc.port")
   val grpcService = new ShoppingCartServiceImpl(system)
-  ShoppingCartServer.start(grpcInterface, grpcPort, system, grpcService)
+  ShoppingCartServer.start(
+    grpcInterface,
+    grpcPort,
+    system,
+    grpcService)
 
   override def onMessage(msg: Nothing): Behavior[Nothing] =
     this

--- a/docs-source/docs/modules/microservices-tutorial/examples/04-shopping-cart-service-java/src/main/java/shopping/cart/Main.java
+++ b/docs-source/docs/modules/microservices-tutorial/examples/04-shopping-cart-service-java/src/main/java/shopping/cart/Main.java
@@ -49,7 +49,8 @@ public class Main extends AbstractBehavior<Void> {
     String grpcInterface =
         system.settings().config().getString("shopping-cart-service.grpc.interface");
     int grpcPort = system.settings().config().getInt("shopping-cart-service.grpc.port");
-    ShoppingCartServer.start(grpcInterface, grpcPort, system, itemPopularityRepository);
+    ShoppingCartServiceImpl grpcService = new ShoppingCartServiceImpl(system, itemPopularityRepository);
+    ShoppingCartServer.start(grpcInterface, grpcPort, system, grpcService);
   }
 
   @Override

--- a/docs-source/docs/modules/microservices-tutorial/examples/04-shopping-cart-service-java/src/main/java/shopping/cart/Main.java
+++ b/docs-source/docs/modules/microservices-tutorial/examples/04-shopping-cart-service-java/src/main/java/shopping/cart/Main.java
@@ -49,7 +49,8 @@ public class Main extends AbstractBehavior<Void> {
     String grpcInterface =
         system.settings().config().getString("shopping-cart-service.grpc.interface");
     int grpcPort = system.settings().config().getInt("shopping-cart-service.grpc.port");
-    ShoppingCartServiceImpl grpcService = new ShoppingCartServiceImpl(system, itemPopularityRepository);
+    ShoppingCartServiceImpl grpcService =
+        new ShoppingCartServiceImpl(system, itemPopularityRepository);
     ShoppingCartServer.start(grpcInterface, grpcPort, system, grpcService);
   }
 

--- a/docs-source/docs/modules/microservices-tutorial/examples/04-shopping-cart-service-java/src/main/java/shopping/cart/ShoppingCartServer.java
+++ b/docs-source/docs/modules/microservices-tutorial/examples/04-shopping-cart-service-java/src/main/java/shopping/cart/ShoppingCartServer.java
@@ -19,25 +19,20 @@ public final class ShoppingCartServer {
 
   private ShoppingCartServer() {}
 
-  static void start(
-      String host,
-      int port,
-      ActorSystem<?> system,
-      ItemPopularityRepository itemPopularityRepository) {
-    ShoppingCartServiceImpl impl = new ShoppingCartServiceImpl(system, itemPopularityRepository);
+  static void start(String host, int port, ActorSystem<?> system, ShoppingCartService grpcService) {
     @SuppressWarnings("unchecked")
     Function<HttpRequest, CompletionStage<HttpResponse>> service =
         ServiceHandler.concatOrNotFound(
-            ShoppingCartServiceHandlerFactory.create(impl, system),
+            ShoppingCartServiceHandlerFactory.create(grpcService, system),
             // ServerReflection enabled to support grpcurl without import-path and proto parameters
-            ServerReflection.create(
+            ServerReflection.create( // <1>
                 Collections.singletonList(ShoppingCartService.description), system));
 
     CompletionStage<ServerBinding> bound =
-        Http.get(system).newServerAt(host, port).bind(service::apply);
+        Http.get(system).newServerAt(host, port).bind(service::apply); // <2>
 
     bound.whenComplete(
-        (binding, ex) -> {
+        (binding, ex) -> { // <3>
           if (binding != null) {
             binding.addToCoordinatedShutdown(Duration.ofSeconds(3), system);
             InetSocketAddress address = binding.localAddress();

--- a/docs-source/docs/modules/microservices-tutorial/examples/04-shopping-cart-service-scala/src/main/scala/shopping/cart/Main.scala
+++ b/docs-source/docs/modules/microservices-tutorial/examples/04-shopping-cart-service-scala/src/main/scala/shopping/cart/Main.scala
@@ -59,11 +59,14 @@ class Main(context: ActorContext[Nothing])
       .getString("shopping-cart-service.grpc.interface")
   val grpcPort = system.settings.config
     .getInt("shopping-cart-service.grpc.port")
+  val grpcService = new ShoppingCartServiceImpl(
+    system,
+    itemPopularityRepository)
   ShoppingCartServer.start(
     grpcInterface,
     grpcPort,
     system,
-    itemPopularityRepository)
+    grpcService)
 
   override def onMessage(msg: Nothing): Behavior[Nothing] =
     this

--- a/docs-source/docs/modules/microservices-tutorial/examples/05-shopping-cart-service-java/src/main/java/shopping/cart/Main.java
+++ b/docs-source/docs/modules/microservices-tutorial/examples/05-shopping-cart-service-java/src/main/java/shopping/cart/Main.java
@@ -46,7 +46,8 @@ public class Main extends AbstractBehavior<Void> {
     String grpcInterface =
         system.settings().config().getString("shopping-cart-service.grpc.interface");
     int grpcPort = system.settings().config().getInt("shopping-cart-service.grpc.port");
-    ShoppingCartServer.start(grpcInterface, grpcPort, system, itemPopularityRepository);
+    ShoppingCartServiceImpl grpcService = new ShoppingCartServiceImpl(system, itemPopularityRepository);
+    ShoppingCartServer.start(grpcInterface, grpcPort, system, grpcService);
 
     // tag::PublishEventsProjection[]
     PublishEventsProjection.init(system);

--- a/docs-source/docs/modules/microservices-tutorial/examples/05-shopping-cart-service-java/src/main/java/shopping/cart/Main.java
+++ b/docs-source/docs/modules/microservices-tutorial/examples/05-shopping-cart-service-java/src/main/java/shopping/cart/Main.java
@@ -46,7 +46,8 @@ public class Main extends AbstractBehavior<Void> {
     String grpcInterface =
         system.settings().config().getString("shopping-cart-service.grpc.interface");
     int grpcPort = system.settings().config().getInt("shopping-cart-service.grpc.port");
-    ShoppingCartServiceImpl grpcService = new ShoppingCartServiceImpl(system, itemPopularityRepository);
+    ShoppingCartServiceImpl grpcService =
+        new ShoppingCartServiceImpl(system, itemPopularityRepository);
     ShoppingCartServer.start(grpcInterface, grpcPort, system, grpcService);
 
     // tag::PublishEventsProjection[]

--- a/docs-source/docs/modules/microservices-tutorial/examples/05-shopping-cart-service-java/src/main/java/shopping/cart/ShoppingCartServer.java
+++ b/docs-source/docs/modules/microservices-tutorial/examples/05-shopping-cart-service-java/src/main/java/shopping/cart/ShoppingCartServer.java
@@ -19,25 +19,20 @@ public final class ShoppingCartServer {
 
   private ShoppingCartServer() {}
 
-  static void start(
-      String host,
-      int port,
-      ActorSystem<?> system,
-      ItemPopularityRepository itemPopularityRepository) {
-    ShoppingCartServiceImpl impl = new ShoppingCartServiceImpl(system, itemPopularityRepository);
+  static void start(String host, int port, ActorSystem<?> system, ShoppingCartService grpcService) {
     @SuppressWarnings("unchecked")
     Function<HttpRequest, CompletionStage<HttpResponse>> service =
         ServiceHandler.concatOrNotFound(
-            ShoppingCartServiceHandlerFactory.create(impl, system),
+            ShoppingCartServiceHandlerFactory.create(grpcService, system),
             // ServerReflection enabled to support grpcurl without import-path and proto parameters
-            ServerReflection.create(
+            ServerReflection.create( // <1>
                 Collections.singletonList(ShoppingCartService.description), system));
 
     CompletionStage<ServerBinding> bound =
-        Http.get(system).newServerAt(host, port).bind(service::apply);
+        Http.get(system).newServerAt(host, port).bind(service::apply); // <2>
 
     bound.whenComplete(
-        (binding, ex) -> {
+        (binding, ex) -> { // <3>
           if (binding != null) {
             binding.addToCoordinatedShutdown(Duration.ofSeconds(3), system);
             InetSocketAddress address = binding.localAddress();

--- a/docs-source/docs/modules/microservices-tutorial/examples/05-shopping-cart-service-scala/src/main/scala/shopping/cart/Main.scala
+++ b/docs-source/docs/modules/microservices-tutorial/examples/05-shopping-cart-service-scala/src/main/scala/shopping/cart/Main.scala
@@ -58,11 +58,14 @@ class Main(context: ActorContext[Nothing])
       .getString("shopping-cart-service.grpc.interface")
   val grpcPort = system.settings.config
     .getInt("shopping-cart-service.grpc.port")
+  val grpcService = new ShoppingCartServiceImpl(
+    system,
+    itemPopularityRepository)
   ShoppingCartServer.start(
     grpcInterface,
     grpcPort,
     system,
-    itemPopularityRepository)
+    grpcService)
 
   // tag::PublishEventsProjection[]
   PublishEventsProjection.init(system)

--- a/docs-source/docs/modules/microservices-tutorial/examples/shopping-cart-service-java/src/main/java/shopping/cart/Main.java
+++ b/docs-source/docs/modules/microservices-tutorial/examples/shopping-cart-service-java/src/main/java/shopping/cart/Main.java
@@ -55,7 +55,9 @@ public class Main extends AbstractBehavior<Void> {
     String grpcInterface =
         system.settings().config().getString("shopping-cart-service.grpc.interface");
     int grpcPort = system.settings().config().getInt("shopping-cart-service.grpc.port");
-    ShoppingCartServer.start(grpcInterface, grpcPort, system, itemPopularityRepository);
+    ShoppingCartServiceImpl grpcService =
+        new ShoppingCartServiceImpl(system, itemPopularityRepository);
+    ShoppingCartServer.start(grpcInterface, grpcPort, system, grpcService);
 
     // tag::PublishEventsProjection[]
     PublishEventsProjection.init(system);

--- a/docs-source/docs/modules/microservices-tutorial/examples/shopping-cart-service-java/src/main/java/shopping/cart/ShoppingCartServer.java
+++ b/docs-source/docs/modules/microservices-tutorial/examples/shopping-cart-service-java/src/main/java/shopping/cart/ShoppingCartServer.java
@@ -19,25 +19,20 @@ public final class ShoppingCartServer {
 
   private ShoppingCartServer() {}
 
-  static void start(
-      String host,
-      int port,
-      ActorSystem<?> system,
-      ItemPopularityRepository itemPopularityRepository) {
-    ShoppingCartServiceImpl impl = new ShoppingCartServiceImpl(system, itemPopularityRepository);
+  static void start(String host, int port, ActorSystem<?> system, ShoppingCartService grpcService) {
     @SuppressWarnings("unchecked")
     Function<HttpRequest, CompletionStage<HttpResponse>> service =
         ServiceHandler.concatOrNotFound(
-            ShoppingCartServiceHandlerFactory.create(impl, system),
+            ShoppingCartServiceHandlerFactory.create(grpcService, system),
             // ServerReflection enabled to support grpcurl without import-path and proto parameters
-            ServerReflection.create(
+            ServerReflection.create( // <1>
                 Collections.singletonList(ShoppingCartService.description), system));
 
     CompletionStage<ServerBinding> bound =
-        Http.get(system).newServerAt(host, port).bind(service::apply);
+        Http.get(system).newServerAt(host, port).bind(service::apply); // <2>
 
     bound.whenComplete(
-        (binding, ex) -> {
+        (binding, ex) -> { // <3>
           if (binding != null) {
             binding.addToCoordinatedShutdown(Duration.ofSeconds(3), system);
             InetSocketAddress address = binding.localAddress();

--- a/docs-source/docs/modules/microservices-tutorial/examples/shopping-cart-service-scala/src/main/scala/shopping/cart/Main.scala
+++ b/docs-source/docs/modules/microservices-tutorial/examples/shopping-cart-service-scala/src/main/scala/shopping/cart/Main.scala
@@ -68,11 +68,14 @@ class Main(context: ActorContext[Nothing])
   val grpcPort =
     system.settings.config
       .getInt("shopping-cart-service.grpc.port")
+  val grpcService = new ShoppingCartServiceImpl(
+    system,
+    itemPopularityRepository)
   ShoppingCartServer.start(
     grpcInterface,
     grpcPort,
     system,
-    itemPopularityRepository)
+    grpcService)
 
   // tag::PublishEventsProjection[]
   PublishEventsProjection.init(system)

--- a/docs-source/docs/modules/microservices-tutorial/examples/shopping-order-service-java/src/main/java/shopping/order/Main.java
+++ b/docs-source/docs/modules/microservices-tutorial/examples/shopping-order-service-java/src/main/java/shopping/order/Main.java
@@ -30,7 +30,8 @@ public class Main extends AbstractBehavior<Void> {
     String grpcInterface =
         system.settings().config().getString("shopping-order-service.grpc.interface");
     int grpcPort = system.settings().config().getInt("shopping-order-service.grpc.port");
-    ShoppingOrderServer.start(grpcInterface, grpcPort, system);
+    ShoppingOrderServiceImpl grpcService = new ShoppingOrderServiceImpl();
+    ShoppingOrderServer.start(grpcInterface, grpcPort, system, grpcService);
   }
 
   @Override

--- a/docs-source/docs/modules/microservices-tutorial/examples/shopping-order-service-java/src/main/java/shopping/order/ShoppingOrderServer.java
+++ b/docs-source/docs/modules/microservices-tutorial/examples/shopping-order-service-java/src/main/java/shopping/order/ShoppingOrderServer.java
@@ -19,12 +19,12 @@ public final class ShoppingOrderServer {
 
   private ShoppingOrderServer() {}
 
-  static void start(String host, int port, ActorSystem<?> system) {
-    ShoppingOrderServiceImpl impl = new ShoppingOrderServiceImpl();
+  static void start(
+      String host, int port, ActorSystem<?> system, ShoppingOrderService grpcService) {
     @SuppressWarnings("unchecked")
     Function<HttpRequest, CompletionStage<HttpResponse>> service =
         ServiceHandler.concatOrNotFound(
-            ShoppingOrderServiceHandlerFactory.create(impl, system),
+            ShoppingOrderServiceHandlerFactory.create(grpcService, system),
             // ServerReflection enabled to support grpcurl without import-path and proto parameters
             ServerReflection.create(
                 Collections.singletonList(ShoppingOrderService.description), system));

--- a/docs-source/docs/modules/microservices-tutorial/examples/shopping-order-service-scala/src/main/scala/shopping/order/Main.scala
+++ b/docs-source/docs/modules/microservices-tutorial/examples/shopping-order-service-scala/src/main/scala/shopping/order/Main.scala
@@ -32,7 +32,12 @@ class Main(context: ActorContext[Nothing])
   val grpcPort =
     context.system.settings.config
       .getInt("shopping-order-service.grpc.port")
-  ShoppingOrderServer.start(grpcInterface, grpcPort, system)
+  val grpcService = new ShoppingOrderServiceImpl
+  ShoppingOrderServer.start(
+    grpcInterface,
+    grpcPort,
+    system,
+    grpcService)
 
   override def onMessage(msg: Nothing): Behavior[Nothing] =
     this

--- a/docs-source/docs/modules/microservices-tutorial/examples/shopping-order-service-scala/src/main/scala/shopping/order/ShoppingOrderServer.scala
+++ b/docs-source/docs/modules/microservices-tutorial/examples/shopping-order-service-scala/src/main/scala/shopping/order/ShoppingOrderServer.scala
@@ -18,7 +18,8 @@ object ShoppingOrderServer {
   def start(
       interface: String,
       port: Int,
-      system: ActorSystem[_]): Unit = {
+      system: ActorSystem[_],
+      grpcService: proto.ShoppingOrderService): Unit = {
     implicit val sys: ActorSystem[_] = system
     implicit val ec: ExecutionContext =
       system.executionContext
@@ -26,7 +27,7 @@ object ShoppingOrderServer {
     val service: HttpRequest => Future[HttpResponse] =
       ServiceHandler.concatOrNotFound(
         proto.ShoppingOrderServiceHandler.partial(
-          new ShoppingOrderServiceImpl),
+          grpcService),
         // ServerReflection enabled to support grpcurl without import-path and proto parameters
         ServerReflection.partial(
           List(proto.ShoppingOrderService)))

--- a/docs-source/docs/modules/microservices-tutorial/pages/projection-query.adoc
+++ b/docs-source/docs/modules/microservices-tutorial/pages/projection-query.adoc
@@ -252,7 +252,7 @@ Scala::
 include::example$04-shopping-cart-service-scala/src/main/scala/shopping/cart/ShoppingCartServiceImpl.scala[tag=getItemPopularity]
 ----
 
-For this you have to add the `ItemPopularityRepository` as a constructor parameter to the `ShoppingCartServiceImpl`. The `ItemPopularityRepository` instance is created in [.group-scala]#`Main.scala`# [.group-java]#`Main.java`# so pass that instance as parameter to `ShoppingCartServer.start` and then to  `ShoppingCartServiceImpl`.
+For this you have to add the `ItemPopularityRepository` as a constructor parameter to the `ShoppingCartServiceImpl`. The `ItemPopularityRepository` instance is created in [.group-scala]#`Main.scala`# [.group-java]#`Main.java`# so pass that instance as parameter to `ShoppingCartServiceImpl`.
 
 == Run locally
 

--- a/scripts/copy-identical-files.sh
+++ b/scripts/copy-identical-files.sh
@@ -408,6 +408,9 @@ cp ${SRC} ${tutorial_root}/04-shopping-cart-service-scala/src/main/scala/shoppin
 declare SRC="${tutorial_root}/shopping-cart-service-scala/src/main/scala/shopping/cart/ShoppingCartServer.scala"
 cp ${SRC} ${tutorial_root}/05-shopping-cart-service-scala/src/main/scala/shopping/cart/
 cp ${SRC} ${tutorial_root}/04-shopping-cart-service-scala/src/main/scala/shopping/cart/
+cp ${SRC} ${tutorial_root}/03-shopping-cart-service-scala/src/main/scala/shopping/cart/
+cp ${SRC} ${tutorial_root}/02-shopping-cart-service-scala/src/main/scala/shopping/cart/
+cp ${SRC} ${tutorial_root}/01-shopping-cart-service-scala/src/main/scala/shopping/cart/
 
 declare SRC="${tutorial_root}/shopping-cart-service-scala/src/main/scala/shopping/cart/ShoppingCartServiceImpl.scala"
 cp ${SRC} ${tutorial_root}/05-shopping-cart-service-scala/src/main/scala/shopping/cart/
@@ -459,6 +462,9 @@ cp ${SRC} ${tutorial_root}/04-shopping-cart-service-java/src/main/java/shopping/
 declare SRC="${tutorial_root}/shopping-cart-service-java/src/main/java/shopping/cart/ShoppingCartServer.java"
 cp ${SRC} ${tutorial_root}/05-shopping-cart-service-java/src/main/java/shopping/cart/
 cp ${SRC} ${tutorial_root}/04-shopping-cart-service-java/src/main/java/shopping/cart/
+cp ${SRC} ${tutorial_root}/03-shopping-cart-service-java/src/main/java/shopping/cart/
+cp ${SRC} ${tutorial_root}/02-shopping-cart-service-java/src/main/java/shopping/cart/
+cp ${SRC} ${tutorial_root}/01-shopping-cart-service-java/src/main/java/shopping/cart/
 
 declare SRC="${tutorial_root}/shopping-cart-service-java/src/main/java/shopping/cart/ShoppingCartServiceImpl.java"
 cp ${SRC} ${tutorial_root}/05-shopping-cart-service-java/src/main/java/shopping/cart/
@@ -496,13 +502,6 @@ cp ${SRC} ${tutorial_root}/02-shopping-cart-service-scala/src/main/resources/
 
 cp ${SRC} ${tutorial_root}/03-shopping-cart-service-java/src/main/resources/
 cp ${SRC} ${tutorial_root}/02-shopping-cart-service-java/src/main/resources/
-
-# from 03
-declare SRC="${tutorial_root}/03-shopping-cart-service-scala/src/main/scala/shopping/cart/ShoppingCartServer.scala"
-cp ${SRC} ${tutorial_root}/02-shopping-cart-service-scala/src/main/scala/shopping/cart/
-
-declare SRC="${tutorial_root}/03-shopping-cart-service-java/src/main/java/shopping/cart/ShoppingCartServer.java"
-cp ${SRC} ${tutorial_root}/02-shopping-cart-service-java/src/main/java/shopping/cart/
 
 # from 02
 declare SRC="${tutorial_root}/02-shopping-cart-service-scala/src/main/protobuf/ShoppingCartService.proto"


### PR DESCRIPTION
* instead of creating the ShoppingCartServiceImpl in ShoppingCartServer
* better design, and makes the tutorial flow better since the addition of the
  ItemPopularityRepository is not needed in the ShoppingCartServer
* more identical files
