### PR TITLE
Show the real site to Gustav (including edit links)

### DIFF
--- a/docs-source/site.yml
+++ b/docs-source/site.yml
@@ -4,12 +4,10 @@ site:
   
 content:
   sources:
-#  - url: git@github.com:akka/akka-platform-guide.git
-  - url: ./../
+  - url: git@github.com:akka/akka-platform-guide.git
     start-paths:
     - docs-source/docs
-#    branches: [main]
-    branches: [HEAD]
+    branches: [main]
 
 
 ui: 

--- a/scripts/deploy-site.sh
+++ b/scripts/deploy-site.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-make html-author-mode
+make all
 eval "$(ssh-agent -s)"
 echo $SCP_SECRET | base64 -d > /tmp/id_rsa
 chmod 600 /tmp/id_rsa


### PR DESCRIPTION
I still don't get the "Edit this page" links to work with the relative sources url, but it works with the real git url using the main branch.
This makes the preview deploy to Gustav use the `site.yml` so no TODOs will show anymore.

References #303