### PR TITLE
Prepare downloads from make

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+version: ~> 1.0
+
 language: scala
 services:
   - docker
@@ -172,11 +174,6 @@ jobs:
       name: "Run the link checker"
       if: type == cron
 
-#    - stage: publish
-#      script:
-#        - scripts/deploy-site.sh
-#      name: "Publish snapshot site"
-
 stages:
   - name: drop-travis-caches
     # to drop caches trigger a custom build with
@@ -192,9 +189,6 @@ stages:
     if: (NOT tag =~ ^v) AND (type != cron)
 
   - name: site
-
-#  - name: publish
-#    if: (branch = main AND type = push) AND NOT fork
 
 after_failure:
   - docker-compose logs

--- a/.travis.yml
+++ b/.travis.yml
@@ -174,7 +174,6 @@ jobs:
 
     - stage: publish
       script:
-        - scripts/prepare-downloads.sh
         - scripts/deploy-site.sh
       name: "Publish snapshot site"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -172,10 +172,10 @@ jobs:
       name: "Run the link checker"
       if: type == cron
 
-    - stage: publish
-      script:
-        - scripts/deploy-site.sh
-      name: "Publish snapshot site"
+#    - stage: publish
+#      script:
+#        - scripts/deploy-site.sh
+#      name: "Publish snapshot site"
 
 stages:
   - name: drop-travis-caches
@@ -193,8 +193,8 @@ stages:
 
   - name: site
 
-  - name: publish
-    if: (branch = main AND type = push) AND NOT fork
+#  - name: publish
+#    if: (branch = main AND type = push) AND NOT fork
 
 after_failure:
   - docker-compose logs

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,10 @@ clean:
 docker-image:
 	(cd ${ROOT_DIR}/antora-docker;  docker build -t ${antora_docker_image}:${antora_docker_image_tag} .)
 
-build: clean html
+build: clean prepare-downloads html
+
+prepare-downloads:
+	${ROOT_DIR}/scripts/prepare-downloads.sh
 
 html: clean docker-image
 	docker run \


### PR DESCRIPTION
To create the source download bundles for TechHub, they need to be packaged via `make`.

We do not need to publish to Gustav anymore. Those URLs redirect to TechHub.