### PR TITLE
Add space: "Howto migrate" --> "How to migrate"

### DIFF
--- a/docs-source/docs/modules/how-to/pages/from-crud-to-eventsourcing.adoc
+++ b/docs-source/docs/modules/how-to/pages/from-crud-to-eventsourcing.adoc
@@ -1,4 +1,4 @@
-= Howto migrate from CRUD to Event Sourcing
+= How to migrate from CRUD to Event Sourcing
 
 
 include::partial$include.adoc[]


### PR DESCRIPTION
Just a typo fix spotted while discussing with Oliver.