### PR TITLE
Run Link Validator as Github action

### DIFF
--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -1,0 +1,34 @@
+name: Link Validator
+
+on:
+  # TODO remove `on push` and `on pull_request_target`
+  push:
+    branches: [main]
+  pull_request_target:
+    branches: [main]
+  schedule:
+    - cron:  '0 6 * * *'
+
+jobs:
+  test:
+    runs-on: ubuntu-18.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Run Antora
+        run: make all
+
+      - name: Set up JDK 11
+        uses: olafurpg/setup-scala@v10
+        with:
+          java-version: adopt@1.11.0-9
+
+      - name: Cache Coursier cache
+        uses: coursier/cache-action@v5
+
+      - name: Install Coursier comman line tool
+        run: curl -fLo cs https://git.io/coursier-cli-linux && chmod +x cs && ./cs
+
+      - name: Run Link Validator
+        run: cs launch net.runne::site-link-validator:0.1.11 -- scripts/validator.conf

--- a/docs-source/docs/modules/concepts/partials/include.adoc
+++ b/docs-source/docs/modules/concepts/partials/include.adoc
@@ -28,7 +28,7 @@ include::ROOT:partial$include.adoc[]
 
 :reactive-principles:  https://principles.reactive.foundation
 
-:reactive-streams:  http://www.reactive-streams.org
+:reactive-streams:  https://www.reactive-streams.org
 
 :reactive-microservices-ebook: https://www.lightbend.com/ebooks/reactive-microservices-architecture-design-principles-for-distributed-systems-oreilly
 

--- a/scripts/validator.conf
+++ b/scripts/validator.conf
@@ -1,0 +1,24 @@
+// config for https://github.com/ennru/site-link-validator/
+site-link-validator {
+  root-dir = "./target/"
+  # relative to `root-dir`
+  start-file = "index.html"
+
+  # Resolves URLs with the given prefix as local files instead
+  link-mappings = [
+    {
+      prefix = "https://developer.lightbend.com/docs/akka-platform-guide"
+      replace = ""
+    }
+  ]
+
+  ignore-missing-local-files-regex = ""
+
+  ignore-prefixes = [
+    "https://github.com/"
+  ]
+
+  non-https-whitelist = [
+    "http://www.reactive-streams.org"
+  ]
+}

--- a/scripts/validator.conf
+++ b/scripts/validator.conf
@@ -15,10 +15,5 @@ site-link-validator {
   ignore-missing-local-files-regex = ""
 
   ignore-prefixes = [
-    "https://github.com/"
-  ]
-
-  non-https-whitelist = [
-    "http://www.reactive-streams.org"
   ]
 }


### PR DESCRIPTION
This is an experiment to use my little hobby project to validate links in the Platform Guide.

The report will only show in the log and does not fail for missing links right now.