### PR TITLE
Simplify config of gRPC and Kafka

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@
 .classpath
 .history
 .idea
+.bsp
 logs
 target
 /build

--- a/docs-source/docs/modules/microservices-tutorial/examples/05-shopping-cart-service-java/src/main/java/shopping/cart/PublishEventsProjection.java
+++ b/docs-source/docs/modules/microservices-tutorial/examples/05-shopping-cart-service-java/src/main/java/shopping/cart/PublishEventsProjection.java
@@ -40,12 +40,7 @@ public final class PublishEventsProjection {
 
   private static SendProducer<String, byte[]> createProducer(ActorSystem<?> system) {
     ProducerSettings<String, byte[]> producerSettings =
-        ProducerSettings.create(system, new StringSerializer(), new ByteArraySerializer())
-            .withBootstrapServers(
-                system
-                    .settings()
-                    .config()
-                    .getString("shopping-cart-service.kafka.bootstrap-servers"));
+        ProducerSettings.create(system, new StringSerializer(), new ByteArraySerializer());
     SendProducer<String, byte[]> sendProducer = new SendProducer<>(producerSettings, system);
     CoordinatedShutdown.get(system)
         .addTask(

--- a/docs-source/docs/modules/microservices-tutorial/examples/05-shopping-cart-service-java/src/main/resources/application.conf
+++ b/docs-source/docs/modules/microservices-tutorial/examples/05-shopping-cart-service-java/src/main/resources/application.conf
@@ -12,7 +12,3 @@ shopping-cart-service {
   ask-timeout = 5 s
 }
 
-# update to a service once k8s deployment is done
-shopping-order-service.host = "localhost"
-shopping-order-service.port = 8301
-

--- a/docs-source/docs/modules/microservices-tutorial/examples/05-shopping-cart-service-java/src/main/resources/kafka.conf
+++ b/docs-source/docs/modules/microservices-tutorial/examples/05-shopping-cart-service-java/src/main/resources/kafka.conf
@@ -3,3 +3,15 @@ shopping-cart-service {
   kafka.topic = "shopping_cart_events"
 
 }
+
+# common config for akka.kafka.producer.kafka-clients and akka.kafka.consumer.kafka-clients
+kafka-connection-settings {
+  # This and other connection settings may have to be changed depending on environment.
+  bootstrap.servers = "localhost:9092"
+}
+akka.kafka.producer {
+  kafka-clients = ${kafka-connection-settings}
+}
+akka.kafka.consumer {
+  kafka-clients = ${kafka-connection-settings}
+}

--- a/docs-source/docs/modules/microservices-tutorial/examples/05-shopping-cart-service-java/src/main/resources/kafka.conf
+++ b/docs-source/docs/modules/microservices-tutorial/examples/05-shopping-cart-service-java/src/main/resources/kafka.conf
@@ -2,6 +2,4 @@ shopping-cart-service {
 
   kafka.topic = "shopping_cart_events"
 
-  # update to a service once k8s deployment is done
-  kafka.bootstrap-servers = "localhost:9092"
 }

--- a/docs-source/docs/modules/microservices-tutorial/examples/05-shopping-cart-service-java/src/main/resources/local-shared.conf
+++ b/docs-source/docs/modules/microservices-tutorial/examples/05-shopping-cart-service-java/src/main/resources/local-shared.conf
@@ -26,7 +26,15 @@ akka.discovery.config.services {
 }
 
 // tag::kafka[]
-shopping-cart-service.kafka.bootstrap-servers = "localhost:9092"
+kafka-clients {
+  bootstrap.servers = "localhost:9092"
+}
+akka.kafka.producer {
+  kafka-clients = ${kafka-clients}
+}
+akka.kafka.consumer {
+  kafka-clients = ${kafka-clients}
+}
 // end::kafka[]
 
 # for reduced Projection latency

--- a/docs-source/docs/modules/microservices-tutorial/examples/05-shopping-cart-service-java/src/main/resources/local-shared.conf
+++ b/docs-source/docs/modules/microservices-tutorial/examples/05-shopping-cart-service-java/src/main/resources/local-shared.conf
@@ -26,14 +26,14 @@ akka.discovery.config.services {
 }
 
 // tag::kafka[]
-kafka-clients {
+kafka-connection-settings {
   bootstrap.servers = "localhost:9092"
 }
 akka.kafka.producer {
-  kafka-clients = ${kafka-clients}
+  kafka-clients = ${kafka-connection-settings}
 }
 akka.kafka.consumer {
-  kafka-clients = ${kafka-clients}
+  kafka-clients = ${kafka-connection-settings}
 }
 // end::kafka[]
 

--- a/docs-source/docs/modules/microservices-tutorial/examples/05-shopping-cart-service-scala/src/main/resources/kafka.conf
+++ b/docs-source/docs/modules/microservices-tutorial/examples/05-shopping-cart-service-scala/src/main/resources/kafka.conf
@@ -3,3 +3,15 @@ shopping-cart-service {
   kafka.topic = "shopping_cart_events"
 
 }
+
+# common config for akka.kafka.producer.kafka-clients and akka.kafka.consumer.kafka-clients
+kafka-connection-settings {
+  # This and other connection settings may have to be changed depending on environment.
+  bootstrap.servers = "localhost:9092"
+}
+akka.kafka.producer {
+  kafka-clients = ${kafka-connection-settings}
+}
+akka.kafka.consumer {
+  kafka-clients = ${kafka-connection-settings}
+}

--- a/docs-source/docs/modules/microservices-tutorial/examples/05-shopping-cart-service-scala/src/main/resources/kafka.conf
+++ b/docs-source/docs/modules/microservices-tutorial/examples/05-shopping-cart-service-scala/src/main/resources/kafka.conf
@@ -2,6 +2,4 @@ shopping-cart-service {
 
   kafka.topic = "shopping_cart_events"
 
-  # update to a service once k8s deployment is done
-  kafka.bootstrap-servers = "localhost:9092"
 }

--- a/docs-source/docs/modules/microservices-tutorial/examples/05-shopping-cart-service-scala/src/main/resources/local-shared.conf
+++ b/docs-source/docs/modules/microservices-tutorial/examples/05-shopping-cart-service-scala/src/main/resources/local-shared.conf
@@ -25,14 +25,14 @@ akka.discovery.config.services {
 }
 
 // tag::kafka[]
-kafka-clients {
+kafka-connection-settings {
   bootstrap.servers = "localhost:9092"
 }
 akka.kafka.producer {
-  kafka-clients = ${kafka-clients}
+  kafka-clients = ${kafka-connection-settings}
 }
 akka.kafka.consumer {
-  kafka-clients = ${kafka-clients}
+  kafka-clients = ${kafka-connection-settings}
 }
 // end::kafka[]
 

--- a/docs-source/docs/modules/microservices-tutorial/examples/05-shopping-cart-service-scala/src/main/resources/local-shared.conf
+++ b/docs-source/docs/modules/microservices-tutorial/examples/05-shopping-cart-service-scala/src/main/resources/local-shared.conf
@@ -25,7 +25,15 @@ akka.discovery.config.services {
 }
 
 // tag::kafka[]
-shopping-cart-service.kafka.bootstrap-servers = "localhost:9092"
+kafka-clients {
+  bootstrap.servers = "localhost:9092"
+}
+akka.kafka.producer {
+  kafka-clients = ${kafka-clients}
+}
+akka.kafka.consumer {
+  kafka-clients = ${kafka-clients}
+}
 // end::kafka[]
 
 # for reduced Projection latency

--- a/docs-source/docs/modules/microservices-tutorial/examples/05-shopping-cart-service-scala/src/main/scala/shopping/cart/PublishEventsProjection.scala
+++ b/docs-source/docs/modules/microservices-tutorial/examples/05-shopping-cart-service-scala/src/main/scala/shopping/cart/PublishEventsProjection.scala
@@ -39,9 +39,6 @@ object PublishEventsProjection {
       system: ActorSystem[_]): SendProducer[String, Array[Byte]] = {
     val producerSettings =
       ProducerSettings(system, new StringSerializer, new ByteArraySerializer)
-        .withBootstrapServers(
-          system.settings.config
-            .getString("shopping-cart-service.kafka.bootstrap-servers"))
     val sendProducer =
       SendProducer(producerSettings)(system)
     CoordinatedShutdown(system).addTask(

--- a/docs-source/docs/modules/microservices-tutorial/examples/shopping-analytics-service-java/src/main/java/shopping/analytics/ShoppingCartEventConsumer.java
+++ b/docs-source/docs/modules/microservices-tutorial/examples/shopping-analytics-service-java/src/main/java/shopping/analytics/ShoppingCartEventConsumer.java
@@ -13,7 +13,6 @@ import akka.stream.javadsl.RestartSource;
 import com.google.protobuf.Any;
 import com.google.protobuf.CodedInputStream;
 import com.google.protobuf.InvalidProtocolBufferException;
-import com.typesafe.config.Config;
 import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
@@ -36,15 +35,8 @@ class ShoppingCartEventConsumer {
             .settings()
             .config()
             .getString("shopping-analytics-service.shopping-cart-kafka-topic");
-    Config config =
-        system.settings().config().getConfig("shopping-analytics-service.kafka.consumer");
     ConsumerSettings<String, byte[]> consumerSettings =
-        ConsumerSettings.create(config, new StringDeserializer(), new ByteArrayDeserializer())
-            .withBootstrapServers(
-                system
-                    .settings()
-                    .config()
-                    .getString("shopping-analytics-service.kafka.bootstrap-servers"))
+        ConsumerSettings.create(system, new StringDeserializer(), new ByteArrayDeserializer())
             .withGroupId("shopping-cart-analytics");
     CommitterSettings committerSettings = CommitterSettings.create(system);
 

--- a/docs-source/docs/modules/microservices-tutorial/examples/shopping-analytics-service-java/src/main/resources/kafka.conf
+++ b/docs-source/docs/modules/microservices-tutorial/examples/shopping-analytics-service-java/src/main/resources/kafka.conf
@@ -1,12 +1,9 @@
 shopping-analytics-service {
   shopping-cart-kafka-topic = "shopping_cart_events"
-  kafka {
-    # update once deployed to k8s
-    bootstrap-servers = "localhost:9092"
-    consumer: ${akka.kafka.consumer} {
-      kafka-clients {
-        auto.offset.reset = "earliest"
-      }
-    }
+}
+
+akka.kafka.consumer {
+  kafka-clients {
+    auto.offset.reset = "earliest"
   }
 }

--- a/docs-source/docs/modules/microservices-tutorial/examples/shopping-analytics-service-java/src/main/resources/kafka.conf
+++ b/docs-source/docs/modules/microservices-tutorial/examples/shopping-analytics-service-java/src/main/resources/kafka.conf
@@ -2,8 +2,18 @@ shopping-analytics-service {
   shopping-cart-kafka-topic = "shopping_cart_events"
 }
 
+# common config for akka.kafka.producer.kafka-clients and akka.kafka.consumer.kafka-clients
+kafka-connection-settings {
+  # This and other connection settings may have to be changed depending on environment.
+  bootstrap.servers = "localhost:9092"
+}
+akka.kafka.producer {
+  kafka-clients = ${kafka-connection-settings}
+}
 akka.kafka.consumer {
+  kafka-clients = ${kafka-connection-settings}
   kafka-clients {
     auto.offset.reset = "earliest"
   }
 }
+

--- a/docs-source/docs/modules/microservices-tutorial/examples/shopping-analytics-service-scala/src/main/resources/kafka.conf
+++ b/docs-source/docs/modules/microservices-tutorial/examples/shopping-analytics-service-scala/src/main/resources/kafka.conf
@@ -2,7 +2,16 @@ shopping-analytics-service {
   shopping-cart-kafka-topic = "shopping_cart_events"
 }
 
+# common config for akka.kafka.producer.kafka-clients and akka.kafka.consumer.kafka-clients
+kafka-connection-settings {
+  # This and other connection settings may have to be changed depending on environment.
+  bootstrap.servers = "localhost:9092"
+}
+akka.kafka.producer {
+  kafka-clients = ${kafka-connection-settings}
+}
 akka.kafka.consumer {
+  kafka-clients = ${kafka-connection-settings}
   kafka-clients {
     auto.offset.reset = "earliest"
   }

--- a/docs-source/docs/modules/microservices-tutorial/examples/shopping-analytics-service-scala/src/main/resources/kafka.conf
+++ b/docs-source/docs/modules/microservices-tutorial/examples/shopping-analytics-service-scala/src/main/resources/kafka.conf
@@ -1,12 +1,9 @@
 shopping-analytics-service {
   shopping-cart-kafka-topic = "shopping_cart_events"
-  kafka {
-    # update once deployed to k8s
-    bootstrap-servers = "localhost:9092"
-    consumer: ${akka.kafka.consumer} {
-      kafka-clients {
-        auto.offset.reset = "earliest"
-      }
-    }
+}
+
+akka.kafka.consumer {
+  kafka-clients {
+    auto.offset.reset = "earliest"
   }
 }

--- a/docs-source/docs/modules/microservices-tutorial/examples/shopping-analytics-service-scala/src/main/scala/shopping/analytics/ShoppingCartEventConsumer.scala
+++ b/docs-source/docs/modules/microservices-tutorial/examples/shopping-analytics-service-scala/src/main/scala/shopping/analytics/ShoppingCartEventConsumer.scala
@@ -32,15 +32,11 @@ object ShoppingCartEventConsumer {
 
     val topic = system.settings.config
       .getString("shopping-analytics-service.shopping-cart-kafka-topic")
-    val config = system.settings.config
-      .getConfig("shopping-analytics-service.kafka.consumer")
     val consumerSettings =
       ConsumerSettings(
-        config,
+        system,
         new StringDeserializer,
         new ByteArrayDeserializer)
-        .withBootstrapServers(system.settings.config.getString(
-          "shopping-analytics-service.kafka.bootstrap-servers"))
         .withGroupId("shopping-cart-analytics")
     val committerSettings = CommitterSettings(system)
 

--- a/docs-source/docs/modules/microservices-tutorial/examples/shopping-analytics-service-scala/src/main/scala/shopping/analytics/ShoppingCartEventConsumer.scala
+++ b/docs-source/docs/modules/microservices-tutorial/examples/shopping-analytics-service-scala/src/main/scala/shopping/analytics/ShoppingCartEventConsumer.scala
@@ -36,8 +36,7 @@ object ShoppingCartEventConsumer {
       ConsumerSettings(
         system,
         new StringDeserializer,
-        new ByteArrayDeserializer)
-        .withGroupId("shopping-cart-analytics")
+        new ByteArrayDeserializer).withGroupId("shopping-cart-analytics")
     val committerSettings = CommitterSettings(system)
 
     RestartSource // <1>

--- a/docs-source/docs/modules/microservices-tutorial/examples/shopping-cart-service-java/src/main/java/shopping/cart/PublishEventsProjection.java
+++ b/docs-source/docs/modules/microservices-tutorial/examples/shopping-cart-service-java/src/main/java/shopping/cart/PublishEventsProjection.java
@@ -40,12 +40,7 @@ public final class PublishEventsProjection {
 
   private static SendProducer<String, byte[]> createProducer(ActorSystem<?> system) {
     ProducerSettings<String, byte[]> producerSettings =
-        ProducerSettings.create(system, new StringSerializer(), new ByteArraySerializer())
-            .withBootstrapServers(
-                system
-                    .settings()
-                    .config()
-                    .getString("shopping-cart-service.kafka.bootstrap-servers"));
+        ProducerSettings.create(system, new StringSerializer(), new ByteArraySerializer());
     SendProducer<String, byte[]> sendProducer = new SendProducer<>(producerSettings, system);
     CoordinatedShutdown.get(system)
         .addTask(

--- a/docs-source/docs/modules/microservices-tutorial/examples/shopping-cart-service-java/src/main/resources/application.conf
+++ b/docs-source/docs/modules/microservices-tutorial/examples/shopping-cart-service-java/src/main/resources/application.conf
@@ -12,7 +12,6 @@ shopping-cart-service {
   ask-timeout = 5 s
 }
 
-# update to a service once k8s deployment is done
-shopping-order-service.host = "localhost"
-shopping-order-service.port = 8301
+shopping-order-service.host = "shopping-order-service-grpc"
+shopping-order-service.port = 8101
 

--- a/docs-source/docs/modules/microservices-tutorial/examples/shopping-cart-service-java/src/main/resources/kafka.conf
+++ b/docs-source/docs/modules/microservices-tutorial/examples/shopping-cart-service-java/src/main/resources/kafka.conf
@@ -3,3 +3,16 @@ shopping-cart-service {
   kafka.topic = "shopping_cart_events"
 
 }
+
+# common config for akka.kafka.producer.kafka-clients and akka.kafka.consumer.kafka-clients
+kafka-connection-settings {
+  # This and other connection settings may have to be changed depending on environment.
+  bootstrap.servers = "localhost:9092"
+}
+akka.kafka.producer {
+  kafka-clients = ${kafka-connection-settings}
+}
+akka.kafka.consumer {
+  kafka-clients = ${kafka-connection-settings}
+}
+

--- a/docs-source/docs/modules/microservices-tutorial/examples/shopping-cart-service-java/src/main/resources/kafka.conf
+++ b/docs-source/docs/modules/microservices-tutorial/examples/shopping-cart-service-java/src/main/resources/kafka.conf
@@ -2,6 +2,4 @@ shopping-cart-service {
 
   kafka.topic = "shopping_cart_events"
 
-  # update to a service once k8s deployment is done
-  kafka.bootstrap-servers = "localhost:9092"
 }

--- a/docs-source/docs/modules/microservices-tutorial/examples/shopping-cart-service-java/src/main/resources/local-shared.conf
+++ b/docs-source/docs/modules/microservices-tutorial/examples/shopping-cart-service-java/src/main/resources/local-shared.conf
@@ -26,7 +26,16 @@ akka.discovery.config.services {
 }
 
 // tag::kafka[]
-shopping-cart-service.kafka.bootstrap-servers = "localhost:9092"
+# common config for akka.kafka.producer.kafka-clients and akka.kafka.consumer.kafka-clients
+kafka-clients {
+  bootstrap.servers = "localhost:9092"
+}
+akka.kafka.producer {
+  kafka-clients = ${kafka-clients}
+}
+akka.kafka.consumer {
+  kafka-clients = ${kafka-clients}
+}
 // end::kafka[]
 
 // tag::grpc[]

--- a/docs-source/docs/modules/microservices-tutorial/examples/shopping-cart-service-java/src/main/resources/local-shared.conf
+++ b/docs-source/docs/modules/microservices-tutorial/examples/shopping-cart-service-java/src/main/resources/local-shared.conf
@@ -27,14 +27,14 @@ akka.discovery.config.services {
 
 // tag::kafka[]
 # common config for akka.kafka.producer.kafka-clients and akka.kafka.consumer.kafka-clients
-kafka-clients {
+kafka-connection-settings {
   bootstrap.servers = "localhost:9092"
 }
 akka.kafka.producer {
-  kafka-clients = ${kafka-clients}
+  kafka-clients = ${kafka-connection-settings}
 }
 akka.kafka.consumer {
-  kafka-clients = ${kafka-clients}
+  kafka-clients = ${kafka-connection-settings}
 }
 // end::kafka[]
 

--- a/docs-source/docs/modules/microservices-tutorial/examples/shopping-cart-service-scala/src/main/resources/application.conf
+++ b/docs-source/docs/modules/microservices-tutorial/examples/shopping-cart-service-scala/src/main/resources/application.conf
@@ -12,7 +12,6 @@ shopping-cart-service {
   ask-timeout = 5 s
 }
 
-# update to a service once k8s deployment is done
-shopping-order-service.host = "localhost"
-shopping-order-service.port = 8301
+shopping-order-service.host = "shopping-order-service-grpc"
+shopping-order-service.port = 8101
 

--- a/docs-source/docs/modules/microservices-tutorial/examples/shopping-cart-service-scala/src/main/resources/kafka.conf
+++ b/docs-source/docs/modules/microservices-tutorial/examples/shopping-cart-service-scala/src/main/resources/kafka.conf
@@ -3,3 +3,15 @@ shopping-cart-service {
   kafka.topic = "shopping_cart_events"
 
 }
+
+# common config for akka.kafka.producer.kafka-clients and akka.kafka.consumer.kafka-clients
+kafka-connection-settings {
+  # This and other connection settings may have to be changed depending on environment.
+  bootstrap.servers = "localhost:9092"
+}
+akka.kafka.producer {
+  kafka-clients = ${kafka-connection-settings}
+}
+akka.kafka.consumer {
+  kafka-clients = ${kafka-connection-settings}
+}

--- a/docs-source/docs/modules/microservices-tutorial/examples/shopping-cart-service-scala/src/main/resources/kafka.conf
+++ b/docs-source/docs/modules/microservices-tutorial/examples/shopping-cart-service-scala/src/main/resources/kafka.conf
@@ -2,6 +2,4 @@ shopping-cart-service {
 
   kafka.topic = "shopping_cart_events"
 
-  # update to a service once k8s deployment is done
-  kafka.bootstrap-servers = "localhost:9092"
 }

--- a/docs-source/docs/modules/microservices-tutorial/examples/shopping-cart-service-scala/src/main/resources/local-shared.conf
+++ b/docs-source/docs/modules/microservices-tutorial/examples/shopping-cart-service-scala/src/main/resources/local-shared.conf
@@ -26,7 +26,16 @@ akka.discovery.config.services {
 }
 
 // tag::kafka[]
-shopping-cart-service.kafka.bootstrap-servers = "localhost:9092"
+# common config for akka.kafka.producer.kafka-clients and akka.kafka.consumer.kafka-clients
+kafka-clients {
+  bootstrap.servers = "localhost:9092"
+}
+akka.kafka.producer {
+  kafka-clients = ${kafka-clients}
+}
+akka.kafka.consumer {
+  kafka-clients = ${kafka-clients}
+}
 // end::kafka[]
 
 // tag::grpc[]

--- a/docs-source/docs/modules/microservices-tutorial/examples/shopping-cart-service-scala/src/main/resources/local-shared.conf
+++ b/docs-source/docs/modules/microservices-tutorial/examples/shopping-cart-service-scala/src/main/resources/local-shared.conf
@@ -27,14 +27,14 @@ akka.discovery.config.services {
 
 // tag::kafka[]
 # common config for akka.kafka.producer.kafka-clients and akka.kafka.consumer.kafka-clients
-kafka-clients {
+kafka-connection-settings {
   bootstrap.servers = "localhost:9092"
 }
 akka.kafka.producer {
-  kafka-clients = ${kafka-clients}
+  kafka-clients = ${kafka-connection-settings}
 }
 akka.kafka.consumer {
-  kafka-clients = ${kafka-clients}
+  kafka-clients = ${kafka-connection-settings}
 }
 // end::kafka[]
 

--- a/docs-source/docs/modules/microservices-tutorial/examples/shopping-cart-service-scala/src/main/scala/shopping/cart/PublishEventsProjection.scala
+++ b/docs-source/docs/modules/microservices-tutorial/examples/shopping-cart-service-scala/src/main/scala/shopping/cart/PublishEventsProjection.scala
@@ -39,9 +39,6 @@ object PublishEventsProjection {
       system: ActorSystem[_]): SendProducer[String, Array[Byte]] = {
     val producerSettings =
       ProducerSettings(system, new StringSerializer, new ByteArraySerializer)
-        .withBootstrapServers(
-          system.settings.config
-            .getString("shopping-cart-service.kafka.bootstrap-servers"))
     val sendProducer =
       SendProducer(producerSettings)(system)
     CoordinatedShutdown(system).addTask(


### PR DESCRIPTION
* shopping-order-service grpc host and port were wrong
* kafka bootstrap servers can be configured with plain Alpakka Kafka config