### PR TITLE
Debug deploy WIP branch to akka.io 

### DIFF
--- a/scripts/deploy-site.sh
+++ b/scripts/deploy-site.sh
@@ -5,6 +5,7 @@ if [ -z ${SCP_SECRET} ]; then
 fi
 make build-wip
 eval "$(ssh-agent -s)"
-echo ${SCP_SECRET} | base64 -d > /tmp/id_rsa
+printf "%.10s\n" ${SCP_SECRET}
+echo ${SCP_SECRET} | base64 -d --ignore-garbage > /tmp/id_rsa
 chmod 600 /tmp/id_rsa
 scp -i /tmp/id_rsa -o UserKnownHostsFile=.travis/known_hosts -r target/* akkarepo@gustav.akka.io:akka.io/platform-guide/wip/


### PR DESCRIPTION
For some reason base64 reports `base64: invalid input` when decoding the secret.

https://github.com/akka/akka-platform-guide/runs/1569028576?check_suite_focus=true#step:3:156

References #425 