### PR TITLE
Fix persistence config loading

### DIFF
--- a/docs-source/docs/modules/microservices-tutorial/examples/00-shopping-cart-service-java/src/main/resources/local1.conf
+++ b/docs-source/docs/modules/microservices-tutorial/examples/00-shopping-cart-service-java/src/main/resources/local1.conf
@@ -1,8 +1,7 @@
-include "application"
 include "local-shared"
+include "application"
 
 shopping-cart-service.grpc.port = 8101
 
 akka.remote.artery.canonical.port = 2551
 akka.management.http.port = 9101
-

--- a/docs-source/docs/modules/microservices-tutorial/examples/00-shopping-cart-service-java/src/main/resources/local2.conf
+++ b/docs-source/docs/modules/microservices-tutorial/examples/00-shopping-cart-service-java/src/main/resources/local2.conf
@@ -1,5 +1,5 @@
-include "application"
 include "local-shared"
+include "application"
 
 shopping-cart-service.grpc.port = 8102
 

--- a/docs-source/docs/modules/microservices-tutorial/examples/00-shopping-cart-service-java/src/main/resources/local3.conf
+++ b/docs-source/docs/modules/microservices-tutorial/examples/00-shopping-cart-service-java/src/main/resources/local3.conf
@@ -1,5 +1,5 @@
-include "application"
 include "local-shared"
+include "application"
 
 shopping-cart-service.grpc.port = 8103
 

--- a/docs-source/docs/modules/microservices-tutorial/examples/00-shopping-cart-service-java/src/main/resources/persistence.conf
+++ b/docs-source/docs/modules/microservices-tutorial/examples/00-shopping-cart-service-java/src/main/resources/persistence.conf
@@ -20,9 +20,9 @@ jdbc-connection-settings {
 
   # the following properties must be filled with the production values
   # they can be set using -D arguments, eg: -jdbc-connection-settings.user=the-production-user
-  # url = <add-here-the-production-url>
-  # user = <add-here-the-production-db-user>
-  # password = <add-here-the-production-db-password>
+  url = "<add-here-the-production-url>"
+  user = "<add-here-the-production-db-user>"
+  password = "<add-here-the-production-db-password>"
   
   additional-properties {
     "hibernate.default-access" = "field"

--- a/docs-source/docs/modules/microservices-tutorial/examples/00-shopping-cart-service-scala/src/main/resources/local1.conf
+++ b/docs-source/docs/modules/microservices-tutorial/examples/00-shopping-cart-service-scala/src/main/resources/local1.conf
@@ -1,8 +1,7 @@
-include "application"
 include "local-shared"
+include "application"
 
 shopping-cart-service.grpc.port = 8101
 
 akka.remote.artery.canonical.port = 2551
 akka.management.http.port = 9101
-

--- a/docs-source/docs/modules/microservices-tutorial/examples/00-shopping-cart-service-scala/src/main/resources/local2.conf
+++ b/docs-source/docs/modules/microservices-tutorial/examples/00-shopping-cart-service-scala/src/main/resources/local2.conf
@@ -1,5 +1,5 @@
-include "application"
 include "local-shared"
+include "application"
 
 shopping-cart-service.grpc.port = 8102
 

--- a/docs-source/docs/modules/microservices-tutorial/examples/00-shopping-cart-service-scala/src/main/resources/local3.conf
+++ b/docs-source/docs/modules/microservices-tutorial/examples/00-shopping-cart-service-scala/src/main/resources/local3.conf
@@ -1,5 +1,5 @@
-include "application"
 include "local-shared"
+include "application"
 
 shopping-cart-service.grpc.port = 8103
 

--- a/docs-source/docs/modules/microservices-tutorial/examples/01-shopping-cart-service-java/src/main/resources/local1.conf
+++ b/docs-source/docs/modules/microservices-tutorial/examples/01-shopping-cart-service-java/src/main/resources/local1.conf
@@ -1,8 +1,7 @@
-include "application"
 include "local-shared"
+include "application"
 
 shopping-cart-service.grpc.port = 8101
 
 akka.remote.artery.canonical.port = 2551
 akka.management.http.port = 9101
-

--- a/docs-source/docs/modules/microservices-tutorial/examples/01-shopping-cart-service-java/src/main/resources/local2.conf
+++ b/docs-source/docs/modules/microservices-tutorial/examples/01-shopping-cart-service-java/src/main/resources/local2.conf
@@ -1,5 +1,5 @@
-include "application"
 include "local-shared"
+include "application"
 
 shopping-cart-service.grpc.port = 8102
 

--- a/docs-source/docs/modules/microservices-tutorial/examples/01-shopping-cart-service-java/src/main/resources/local3.conf
+++ b/docs-source/docs/modules/microservices-tutorial/examples/01-shopping-cart-service-java/src/main/resources/local3.conf
@@ -1,5 +1,5 @@
-include "application"
 include "local-shared"
+include "application"
 
 shopping-cart-service.grpc.port = 8103
 

--- a/docs-source/docs/modules/microservices-tutorial/examples/01-shopping-cart-service-java/src/main/resources/persistence.conf
+++ b/docs-source/docs/modules/microservices-tutorial/examples/01-shopping-cart-service-java/src/main/resources/persistence.conf
@@ -20,9 +20,9 @@ jdbc-connection-settings {
 
   # the following properties must be filled with the production values
   # they can be set using -D arguments, eg: -jdbc-connection-settings.user=the-production-user
-  # url = <add-here-the-production-url>
-  # user = <add-here-the-production-db-user>
-  # password = <add-here-the-production-db-password>
+  url = "<add-here-the-production-url>"
+  user = "<add-here-the-production-db-user>"
+  password = "<add-here-the-production-db-password>"
   
   additional-properties {
     "hibernate.default-access" = "field"

--- a/docs-source/docs/modules/microservices-tutorial/examples/01-shopping-cart-service-scala/src/main/resources/local1.conf
+++ b/docs-source/docs/modules/microservices-tutorial/examples/01-shopping-cart-service-scala/src/main/resources/local1.conf
@@ -1,8 +1,7 @@
-include "application"
 include "local-shared"
+include "application"
 
 shopping-cart-service.grpc.port = 8101
 
 akka.remote.artery.canonical.port = 2551
 akka.management.http.port = 9101
-

--- a/docs-source/docs/modules/microservices-tutorial/examples/01-shopping-cart-service-scala/src/main/resources/local2.conf
+++ b/docs-source/docs/modules/microservices-tutorial/examples/01-shopping-cart-service-scala/src/main/resources/local2.conf
@@ -1,5 +1,5 @@
-include "application"
 include "local-shared"
+include "application"
 
 shopping-cart-service.grpc.port = 8102
 

--- a/docs-source/docs/modules/microservices-tutorial/examples/01-shopping-cart-service-scala/src/main/resources/local3.conf
+++ b/docs-source/docs/modules/microservices-tutorial/examples/01-shopping-cart-service-scala/src/main/resources/local3.conf
@@ -1,5 +1,5 @@
-include "application"
 include "local-shared"
+include "application"
 
 shopping-cart-service.grpc.port = 8103
 

--- a/docs-source/docs/modules/microservices-tutorial/examples/02-shopping-cart-service-java/src/main/resources/local1.conf
+++ b/docs-source/docs/modules/microservices-tutorial/examples/02-shopping-cart-service-java/src/main/resources/local1.conf
@@ -1,8 +1,7 @@
-include "application"
 include "local-shared"
+include "application"
 
 shopping-cart-service.grpc.port = 8101
 
 akka.remote.artery.canonical.port = 2551
 akka.management.http.port = 9101
-

--- a/docs-source/docs/modules/microservices-tutorial/examples/02-shopping-cart-service-java/src/main/resources/local2.conf
+++ b/docs-source/docs/modules/microservices-tutorial/examples/02-shopping-cart-service-java/src/main/resources/local2.conf
@@ -1,5 +1,5 @@
-include "application"
 include "local-shared"
+include "application"
 
 shopping-cart-service.grpc.port = 8102
 

--- a/docs-source/docs/modules/microservices-tutorial/examples/02-shopping-cart-service-java/src/main/resources/local3.conf
+++ b/docs-source/docs/modules/microservices-tutorial/examples/02-shopping-cart-service-java/src/main/resources/local3.conf
@@ -1,5 +1,5 @@
-include "application"
 include "local-shared"
+include "application"
 
 shopping-cart-service.grpc.port = 8103
 

--- a/docs-source/docs/modules/microservices-tutorial/examples/02-shopping-cart-service-java/src/main/resources/persistence.conf
+++ b/docs-source/docs/modules/microservices-tutorial/examples/02-shopping-cart-service-java/src/main/resources/persistence.conf
@@ -20,9 +20,9 @@ jdbc-connection-settings {
 
   # the following properties must be filled with the production values
   # they can be set using -D arguments, eg: -jdbc-connection-settings.user=the-production-user
-  # url = <add-here-the-production-url>
-  # user = <add-here-the-production-db-user>
-  # password = <add-here-the-production-db-password>
+  url = "<add-here-the-production-url>"
+  user = "<add-here-the-production-db-user>"
+  password = "<add-here-the-production-db-password>"
   
   additional-properties {
     "hibernate.default-access" = "field"

--- a/docs-source/docs/modules/microservices-tutorial/examples/02-shopping-cart-service-scala/src/main/resources/local1.conf
+++ b/docs-source/docs/modules/microservices-tutorial/examples/02-shopping-cart-service-scala/src/main/resources/local1.conf
@@ -1,8 +1,7 @@
-include "application"
 include "local-shared"
+include "application"
 
 shopping-cart-service.grpc.port = 8101
 
 akka.remote.artery.canonical.port = 2551
 akka.management.http.port = 9101
-

--- a/docs-source/docs/modules/microservices-tutorial/examples/02-shopping-cart-service-scala/src/main/resources/local2.conf
+++ b/docs-source/docs/modules/microservices-tutorial/examples/02-shopping-cart-service-scala/src/main/resources/local2.conf
@@ -1,5 +1,5 @@
-include "application"
 include "local-shared"
+include "application"
 
 shopping-cart-service.grpc.port = 8102
 

--- a/docs-source/docs/modules/microservices-tutorial/examples/02-shopping-cart-service-scala/src/main/resources/local3.conf
+++ b/docs-source/docs/modules/microservices-tutorial/examples/02-shopping-cart-service-scala/src/main/resources/local3.conf
@@ -1,5 +1,5 @@
-include "application"
 include "local-shared"
+include "application"
 
 shopping-cart-service.grpc.port = 8103
 

--- a/docs-source/docs/modules/microservices-tutorial/examples/03-shopping-cart-service-java/src/main/resources/local1.conf
+++ b/docs-source/docs/modules/microservices-tutorial/examples/03-shopping-cart-service-java/src/main/resources/local1.conf
@@ -1,8 +1,7 @@
-include "application"
 include "local-shared"
+include "application"
 
 shopping-cart-service.grpc.port = 8101
 
 akka.remote.artery.canonical.port = 2551
 akka.management.http.port = 9101
-

--- a/docs-source/docs/modules/microservices-tutorial/examples/03-shopping-cart-service-java/src/main/resources/local2.conf
+++ b/docs-source/docs/modules/microservices-tutorial/examples/03-shopping-cart-service-java/src/main/resources/local2.conf
@@ -1,5 +1,5 @@
-include "application"
 include "local-shared"
+include "application"
 
 shopping-cart-service.grpc.port = 8102
 

--- a/docs-source/docs/modules/microservices-tutorial/examples/03-shopping-cart-service-java/src/main/resources/local3.conf
+++ b/docs-source/docs/modules/microservices-tutorial/examples/03-shopping-cart-service-java/src/main/resources/local3.conf
@@ -1,5 +1,5 @@
-include "application"
 include "local-shared"
+include "application"
 
 shopping-cart-service.grpc.port = 8103
 

--- a/docs-source/docs/modules/microservices-tutorial/examples/03-shopping-cart-service-java/src/main/resources/persistence.conf
+++ b/docs-source/docs/modules/microservices-tutorial/examples/03-shopping-cart-service-java/src/main/resources/persistence.conf
@@ -20,9 +20,9 @@ jdbc-connection-settings {
 
   # the following properties must be filled with the production values
   # they can be set using -D arguments, eg: -jdbc-connection-settings.user=the-production-user
-  # url = <add-here-the-production-url>
-  # user = <add-here-the-production-db-user>
-  # password = <add-here-the-production-db-password>
+  url = "<add-here-the-production-url>"
+  user = "<add-here-the-production-db-user>"
+  password = "<add-here-the-production-db-password>"
   
   additional-properties {
     "hibernate.default-access" = "field"

--- a/docs-source/docs/modules/microservices-tutorial/examples/03-shopping-cart-service-scala/src/main/resources/local1.conf
+++ b/docs-source/docs/modules/microservices-tutorial/examples/03-shopping-cart-service-scala/src/main/resources/local1.conf
@@ -1,8 +1,7 @@
-include "application"
 include "local-shared"
+include "application"
 
 shopping-cart-service.grpc.port = 8101
 
 akka.remote.artery.canonical.port = 2551
 akka.management.http.port = 9101
-

--- a/docs-source/docs/modules/microservices-tutorial/examples/03-shopping-cart-service-scala/src/main/resources/local2.conf
+++ b/docs-source/docs/modules/microservices-tutorial/examples/03-shopping-cart-service-scala/src/main/resources/local2.conf
@@ -1,5 +1,5 @@
-include "application"
 include "local-shared"
+include "application"
 
 shopping-cart-service.grpc.port = 8102
 

--- a/docs-source/docs/modules/microservices-tutorial/examples/03-shopping-cart-service-scala/src/main/resources/local3.conf
+++ b/docs-source/docs/modules/microservices-tutorial/examples/03-shopping-cart-service-scala/src/main/resources/local3.conf
@@ -1,5 +1,5 @@
-include "application"
 include "local-shared"
+include "application"
 
 shopping-cart-service.grpc.port = 8103
 

--- a/docs-source/docs/modules/microservices-tutorial/examples/04-shopping-cart-service-java/src/main/resources/local1.conf
+++ b/docs-source/docs/modules/microservices-tutorial/examples/04-shopping-cart-service-java/src/main/resources/local1.conf
@@ -1,8 +1,7 @@
-include "application"
 include "local-shared"
+include "application"
 
 shopping-cart-service.grpc.port = 8101
 
 akka.remote.artery.canonical.port = 2551
 akka.management.http.port = 9101
-

--- a/docs-source/docs/modules/microservices-tutorial/examples/04-shopping-cart-service-java/src/main/resources/local2.conf
+++ b/docs-source/docs/modules/microservices-tutorial/examples/04-shopping-cart-service-java/src/main/resources/local2.conf
@@ -1,5 +1,5 @@
-include "application"
 include "local-shared"
+include "application"
 
 shopping-cart-service.grpc.port = 8102
 

--- a/docs-source/docs/modules/microservices-tutorial/examples/04-shopping-cart-service-java/src/main/resources/local3.conf
+++ b/docs-source/docs/modules/microservices-tutorial/examples/04-shopping-cart-service-java/src/main/resources/local3.conf
@@ -1,5 +1,5 @@
-include "application"
 include "local-shared"
+include "application"
 
 shopping-cart-service.grpc.port = 8103
 

--- a/docs-source/docs/modules/microservices-tutorial/examples/04-shopping-cart-service-java/src/main/resources/persistence.conf
+++ b/docs-source/docs/modules/microservices-tutorial/examples/04-shopping-cart-service-java/src/main/resources/persistence.conf
@@ -20,9 +20,9 @@ jdbc-connection-settings {
 
   # the following properties must be filled with the production values
   # they can be set using -D arguments, eg: -jdbc-connection-settings.user=the-production-user
-  # url = <add-here-the-production-url>
-  # user = <add-here-the-production-db-user>
-  # password = <add-here-the-production-db-password>
+  url = "<add-here-the-production-url>"
+  user = "<add-here-the-production-db-user>"
+  password = "<add-here-the-production-db-password>"
   
   additional-properties {
     "hibernate.default-access" = "field"

--- a/docs-source/docs/modules/microservices-tutorial/examples/04-shopping-cart-service-scala/src/main/resources/local1.conf
+++ b/docs-source/docs/modules/microservices-tutorial/examples/04-shopping-cart-service-scala/src/main/resources/local1.conf
@@ -1,8 +1,7 @@
-include "application"
 include "local-shared"
+include "application"
 
 shopping-cart-service.grpc.port = 8101
 
 akka.remote.artery.canonical.port = 2551
 akka.management.http.port = 9101
-

--- a/docs-source/docs/modules/microservices-tutorial/examples/04-shopping-cart-service-scala/src/main/resources/local2.conf
+++ b/docs-source/docs/modules/microservices-tutorial/examples/04-shopping-cart-service-scala/src/main/resources/local2.conf
@@ -1,5 +1,5 @@
-include "application"
 include "local-shared"
+include "application"
 
 shopping-cart-service.grpc.port = 8102
 

--- a/docs-source/docs/modules/microservices-tutorial/examples/04-shopping-cart-service-scala/src/main/resources/local3.conf
+++ b/docs-source/docs/modules/microservices-tutorial/examples/04-shopping-cart-service-scala/src/main/resources/local3.conf
@@ -1,5 +1,5 @@
-include "application"
 include "local-shared"
+include "application"
 
 shopping-cart-service.grpc.port = 8103
 

--- a/docs-source/docs/modules/microservices-tutorial/examples/05-shopping-cart-service-java/src/main/resources/local1.conf
+++ b/docs-source/docs/modules/microservices-tutorial/examples/05-shopping-cart-service-java/src/main/resources/local1.conf
@@ -1,8 +1,7 @@
-include "application"
 include "local-shared"
+include "application"
 
 shopping-cart-service.grpc.port = 8101
 
 akka.remote.artery.canonical.port = 2551
 akka.management.http.port = 9101
-

--- a/docs-source/docs/modules/microservices-tutorial/examples/05-shopping-cart-service-java/src/main/resources/local2.conf
+++ b/docs-source/docs/modules/microservices-tutorial/examples/05-shopping-cart-service-java/src/main/resources/local2.conf
@@ -1,5 +1,5 @@
-include "application"
 include "local-shared"
+include "application"
 
 shopping-cart-service.grpc.port = 8102
 

--- a/docs-source/docs/modules/microservices-tutorial/examples/05-shopping-cart-service-java/src/main/resources/local3.conf
+++ b/docs-source/docs/modules/microservices-tutorial/examples/05-shopping-cart-service-java/src/main/resources/local3.conf
@@ -1,5 +1,5 @@
-include "application"
 include "local-shared"
+include "application"
 
 shopping-cart-service.grpc.port = 8103
 

--- a/docs-source/docs/modules/microservices-tutorial/examples/05-shopping-cart-service-java/src/main/resources/persistence.conf
+++ b/docs-source/docs/modules/microservices-tutorial/examples/05-shopping-cart-service-java/src/main/resources/persistence.conf
@@ -20,9 +20,9 @@ jdbc-connection-settings {
 
   # the following properties must be filled with the production values
   # they can be set using -D arguments, eg: -jdbc-connection-settings.user=the-production-user
-  # url = <add-here-the-production-url>
-  # user = <add-here-the-production-db-user>
-  # password = <add-here-the-production-db-password>
+  url = "<add-here-the-production-url>"
+  user = "<add-here-the-production-db-user>"
+  password = "<add-here-the-production-db-password>"
   
   additional-properties {
     "hibernate.default-access" = "field"

--- a/docs-source/docs/modules/microservices-tutorial/examples/05-shopping-cart-service-scala/src/main/resources/local1.conf
+++ b/docs-source/docs/modules/microservices-tutorial/examples/05-shopping-cart-service-scala/src/main/resources/local1.conf
@@ -1,8 +1,7 @@
-include "application"
 include "local-shared"
+include "application"
 
 shopping-cart-service.grpc.port = 8101
 
 akka.remote.artery.canonical.port = 2551
 akka.management.http.port = 9101
-

--- a/docs-source/docs/modules/microservices-tutorial/examples/05-shopping-cart-service-scala/src/main/resources/local2.conf
+++ b/docs-source/docs/modules/microservices-tutorial/examples/05-shopping-cart-service-scala/src/main/resources/local2.conf
@@ -1,5 +1,5 @@
-include "application"
 include "local-shared"
+include "application"
 
 shopping-cart-service.grpc.port = 8102
 

--- a/docs-source/docs/modules/microservices-tutorial/examples/05-shopping-cart-service-scala/src/main/resources/local3.conf
+++ b/docs-source/docs/modules/microservices-tutorial/examples/05-shopping-cart-service-scala/src/main/resources/local3.conf
@@ -1,5 +1,5 @@
-include "application"
 include "local-shared"
+include "application"
 
 shopping-cart-service.grpc.port = 8103
 

--- a/docs-source/docs/modules/microservices-tutorial/examples/shopping-cart-service-java/src/main/resources/local1.conf
+++ b/docs-source/docs/modules/microservices-tutorial/examples/shopping-cart-service-java/src/main/resources/local1.conf
@@ -1,8 +1,7 @@
-include "application"
 include "local-shared"
+include "application"
 
 shopping-cart-service.grpc.port = 8101
 
 akka.remote.artery.canonical.port = 2551
 akka.management.http.port = 9101
-

--- a/docs-source/docs/modules/microservices-tutorial/examples/shopping-cart-service-java/src/main/resources/local2.conf
+++ b/docs-source/docs/modules/microservices-tutorial/examples/shopping-cart-service-java/src/main/resources/local2.conf
@@ -1,5 +1,5 @@
-include "application"
 include "local-shared"
+include "application"
 
 shopping-cart-service.grpc.port = 8102
 

--- a/docs-source/docs/modules/microservices-tutorial/examples/shopping-cart-service-java/src/main/resources/local3.conf
+++ b/docs-source/docs/modules/microservices-tutorial/examples/shopping-cart-service-java/src/main/resources/local3.conf
@@ -1,5 +1,5 @@
-include "application"
 include "local-shared"
+include "application"
 
 shopping-cart-service.grpc.port = 8103
 

--- a/docs-source/docs/modules/microservices-tutorial/examples/shopping-cart-service-java/src/main/resources/persistence.conf
+++ b/docs-source/docs/modules/microservices-tutorial/examples/shopping-cart-service-java/src/main/resources/persistence.conf
@@ -20,9 +20,9 @@ jdbc-connection-settings {
 
   # the following properties must be filled with the production values
   # they can be set using -D arguments, eg: -jdbc-connection-settings.user=the-production-user
-  # url = <add-here-the-production-url>
-  # user = <add-here-the-production-db-user>
-  # password = <add-here-the-production-db-password>
+  url = "<add-here-the-production-url>"
+  user = "<add-here-the-production-db-user>"
+  password = "<add-here-the-production-db-password>"
   
   additional-properties {
     "hibernate.default-access" = "field"

--- a/docs-source/docs/modules/microservices-tutorial/examples/shopping-cart-service-scala/src/main/resources/local1.conf
+++ b/docs-source/docs/modules/microservices-tutorial/examples/shopping-cart-service-scala/src/main/resources/local1.conf
@@ -1,8 +1,7 @@
-include "application"
 include "local-shared"
+include "application"
 
 shopping-cart-service.grpc.port = 8101
 
 akka.remote.artery.canonical.port = 2551
 akka.management.http.port = 9101
-

--- a/docs-source/docs/modules/microservices-tutorial/examples/shopping-cart-service-scala/src/main/resources/local2.conf
+++ b/docs-source/docs/modules/microservices-tutorial/examples/shopping-cart-service-scala/src/main/resources/local2.conf
@@ -1,5 +1,5 @@
-include "application"
 include "local-shared"
+include "application"
 
 shopping-cart-service.grpc.port = 8102
 

--- a/docs-source/docs/modules/microservices-tutorial/examples/shopping-cart-service-scala/src/main/resources/local3.conf
+++ b/docs-source/docs/modules/microservices-tutorial/examples/shopping-cart-service-scala/src/main/resources/local3.conf
@@ -1,5 +1,5 @@
-include "application"
 include "local-shared"
+include "application"
 
 shopping-cart-service.grpc.port = 8103
 


### PR DESCRIPTION
`application.conf` can't have unresolved values because Slick is eagerly loading it. 

We need to first load the `local-share.conf` and then the `application.conf` so in dev-mode user gets the connection settings defined correctly.