### PR TITLE
includes are wrong

### DIFF
--- a/docs-source/docs/modules/microservices-tutorial/examples/shopping-order-service-scala/src/main/resources/application.conf
+++ b/docs-source/docs/modules/microservices-tutorial/examples/shopping-order-service-scala/src/main/resources/application.conf
@@ -5,3 +5,4 @@ akka {
   loglevel = DEBUG
 }
 
+foo=a

--- a/docs-source/docs/modules/microservices-tutorial/examples/shopping-order-service-scala/src/main/resources/local-shared.conf
+++ b/docs-source/docs/modules/microservices-tutorial/examples/shopping-order-service-scala/src/main/resources/local-shared.conf
@@ -24,3 +24,5 @@ akka.discovery.config.services {
     ]
   }
 }
+
+foo=s

--- a/docs-source/docs/modules/microservices-tutorial/examples/shopping-order-service-scala/src/main/resources/local1.conf
+++ b/docs-source/docs/modules/microservices-tutorial/examples/shopping-order-service-scala/src/main/resources/local1.conf
@@ -1,7 +1,11 @@
-include "application"
 include "local-shared"
+include "application"
 
 shopping-order-service.grpc.port = 8301
 
 akka.remote.artery.canonical.port = 4551
 akka.management.http.port = 9301
+
+#foo=l1
+bar=l1
+bar=l2

--- a/docs-source/docs/modules/microservices-tutorial/examples/shopping-order-service-scala/src/main/scala/shopping/order/Main.scala
+++ b/docs-source/docs/modules/microservices-tutorial/examples/shopping-order-service-scala/src/main/scala/shopping/order/Main.scala
@@ -23,6 +23,8 @@ class Main(context: ActorContext[Nothing])
     extends AbstractBehavior[Nothing](context) {
   val system = context.system
 
+  println(s"# foo=${system.settings.config.getString("foo")} bar=${system.settings.config.getString("bar")}") // FIXME
+
   AkkaManagement(system).start()
   ClusterBootstrap(system).start()
 


### PR DESCRIPTION
@octonato @ennru evidence that your changes in https://github.com/akka/akka-platform-guide/pull/455 are wrong

Run `shopping-order-service-scala` with `sbt -Dconfig.resource=local1.conf run`.

It will print:
```
# foo=a bar=l2
```