### PR TITLE
Fix Cassandra health-check include

### DIFF
--- a/docs-source/docs/modules/how-to/pages/health-checks.adoc
+++ b/docs-source/docs/modules/how-to/pages/health-checks.adoc
@@ -56,7 +56,7 @@ Akka Persistence Cassandra includes a check to validate connectivity, as the ser
 include::microservices-tutorial:example$shopping-cart-service-scala/src/main/resources/persistence.conf[tag=healthchecks-for-cassandra]
 ----
 
-Following Colin Breck's advice, we do not include Cassandra connectivity checks in oue liveness probe.
+Following Colin Breck's advice, we do not include Cassandra connectivity checks in our liveness probe.
 
 Try the readiness check with `curl`
 

--- a/docs-source/docs/modules/microservices-tutorial/examples/00-shopping-cart-service-scala/src/main/resources/persistence.conf
+++ b/docs-source/docs/modules/microservices-tutorial/examples/00-shopping-cart-service-scala/src/main/resources/persistence.conf
@@ -34,6 +34,7 @@ datastax-java-driver {
   advanced.reconnect-on-init = on
 }
 
+# tag::healthchecks-for-cassandra[]
 akka.management {
   health-checks {
     readiness-checks {
@@ -41,4 +42,4 @@ akka.management {
     }
   }
 }
-
+# end::healthchecks-for-cassandra[]

--- a/docs-source/docs/modules/microservices-tutorial/examples/01-shopping-cart-service-scala/src/main/resources/persistence.conf
+++ b/docs-source/docs/modules/microservices-tutorial/examples/01-shopping-cart-service-scala/src/main/resources/persistence.conf
@@ -34,6 +34,7 @@ datastax-java-driver {
   advanced.reconnect-on-init = on
 }
 
+# tag::healthchecks-for-cassandra[]
 akka.management {
   health-checks {
     readiness-checks {
@@ -41,4 +42,4 @@ akka.management {
     }
   }
 }
-
+# end::healthchecks-for-cassandra[]

--- a/docs-source/docs/modules/microservices-tutorial/examples/02-shopping-cart-service-scala/src/main/resources/persistence.conf
+++ b/docs-source/docs/modules/microservices-tutorial/examples/02-shopping-cart-service-scala/src/main/resources/persistence.conf
@@ -34,6 +34,7 @@ datastax-java-driver {
   advanced.reconnect-on-init = on
 }
 
+# tag::healthchecks-for-cassandra[]
 akka.management {
   health-checks {
     readiness-checks {
@@ -41,4 +42,4 @@ akka.management {
     }
   }
 }
-
+# end::healthchecks-for-cassandra[]

--- a/docs-source/docs/modules/microservices-tutorial/examples/03-shopping-cart-service-scala/src/main/resources/persistence.conf
+++ b/docs-source/docs/modules/microservices-tutorial/examples/03-shopping-cart-service-scala/src/main/resources/persistence.conf
@@ -34,6 +34,7 @@ datastax-java-driver {
   advanced.reconnect-on-init = on
 }
 
+# tag::healthchecks-for-cassandra[]
 akka.management {
   health-checks {
     readiness-checks {
@@ -41,4 +42,4 @@ akka.management {
     }
   }
 }
-
+# end::healthchecks-for-cassandra[]

--- a/docs-source/docs/modules/microservices-tutorial/examples/04-shopping-cart-service-scala/src/main/resources/persistence.conf
+++ b/docs-source/docs/modules/microservices-tutorial/examples/04-shopping-cart-service-scala/src/main/resources/persistence.conf
@@ -34,6 +34,7 @@ datastax-java-driver {
   advanced.reconnect-on-init = on
 }
 
+# tag::healthchecks-for-cassandra[]
 akka.management {
   health-checks {
     readiness-checks {
@@ -41,4 +42,4 @@ akka.management {
     }
   }
 }
-
+# end::healthchecks-for-cassandra[]

--- a/docs-source/docs/modules/microservices-tutorial/examples/05-shopping-cart-service-scala/src/main/resources/persistence.conf
+++ b/docs-source/docs/modules/microservices-tutorial/examples/05-shopping-cart-service-scala/src/main/resources/persistence.conf
@@ -34,6 +34,7 @@ datastax-java-driver {
   advanced.reconnect-on-init = on
 }
 
+# tag::healthchecks-for-cassandra[]
 akka.management {
   health-checks {
     readiness-checks {
@@ -41,4 +42,4 @@ akka.management {
     }
   }
 }
-
+# end::healthchecks-for-cassandra[]

--- a/docs-source/docs/modules/microservices-tutorial/examples/shopping-cart-service-scala/src/main/resources/persistence.conf
+++ b/docs-source/docs/modules/microservices-tutorial/examples/shopping-cart-service-scala/src/main/resources/persistence.conf
@@ -34,6 +34,7 @@ datastax-java-driver {
   advanced.reconnect-on-init = on
 }
 
+# tag::healthchecks-for-cassandra[]
 akka.management {
   health-checks {
     readiness-checks {
@@ -41,4 +42,4 @@ akka.management {
     }
   }
 }
-
+# end::healthchecks-for-cassandra[]


### PR DESCRIPTION
I removed too much on my previous PRs. 

Once we move to Scala JDBC, we will need to keep it around somewhere until we get back the full Cassandra example.