### PR TITLE
rename Kafka topic

### DIFF
--- a/docs-source/docs/modules/deployment/pages/aws-msk.adoc
+++ b/docs-source/docs/modules/deployment/pages/aws-msk.adoc
@@ -63,11 +63,11 @@ Save the connect string in an environment variable at the bash prompt of the Pod
 ZOOKEEPER_CONNECT_STRING="<copied ZooKeeper connect string>"
 ----
 
-Create a Kafka `shopping_cart_events` topic with:
+Create a Kafka `shopping-cart-events` topic with:
 
 [source,shell script]
 ----
-bin/kafka-topics.sh --zookeeper ${ZOOKEEPER_CONNECT_STRING} --create --topic shopping_cart_events --replication-factor 3 --partitions 4
+bin/kafka-topics.sh --zookeeper ${ZOOKEEPER_CONNECT_STRING} --create --topic shopping-cart-events --replication-factor 3 --partitions 4
 ----
 
 == Kafka configuration

--- a/docs-source/docs/modules/how-to/examples/shopping-cart-service-cassandra-java/src/main/resources/kafka.conf
+++ b/docs-source/docs/modules/how-to/examples/shopping-cart-service-cassandra-java/src/main/resources/kafka.conf
@@ -1,6 +1,6 @@
 shopping-cart-service {
 
-  kafka.topic = "shopping_cart_events"
+  kafka.topic = "shopping-cart-events"
 
 }
 

--- a/docs-source/docs/modules/how-to/examples/shopping-cart-service-cassandra-java/src/test/java/shopping/cart/IntegrationTest.java
+++ b/docs-source/docs/modules/how-to/examples/shopping-cart-service-cassandra-java/src/test/java/shopping/cart/IntegrationTest.java
@@ -60,7 +60,7 @@ public class IntegrationTest {
                 + "akka.projection.cassandra.offset-store.keyspace = "
                 + KEYSPACE
                 + "\n"
-                + "shopping-cart-service.kafka.topic = \"shopping_cart_events_"
+                + "shopping-cart-service.kafka.topic = \"shopping-cart-events_"
                 + UNIQUE_QUALIFIER
                 + "\"")
         .withFallback(ConfigFactory.load("integration-test.conf"));

--- a/docs-source/docs/modules/how-to/examples/shopping-cart-service-cassandra-scala/src/main/resources/kafka.conf
+++ b/docs-source/docs/modules/how-to/examples/shopping-cart-service-cassandra-scala/src/main/resources/kafka.conf
@@ -1,6 +1,6 @@
 shopping-cart-service {
 
-  kafka.topic = "shopping_cart_events"
+  kafka.topic = "shopping-cart-events"
 
 }
 

--- a/docs-source/docs/modules/how-to/examples/shopping-cart-service-cassandra-scala/src/test/scala/shopping/cart/IntegrationSpec.scala
+++ b/docs-source/docs/modules/how-to/examples/shopping-cart-service-cassandra-scala/src/test/scala/shopping/cart/IntegrationSpec.scala
@@ -72,7 +72,7 @@ object IntegrationSpec {
       
       akka.projection.cassandra.offset-store.keyspace = $keyspace
       
-      shopping-cart-service.kafka.topic = "shopping_cart_events_$uniqueQualifier"
+      shopping-cart-service.kafka.topic = "shopping-cart-events_$uniqueQualifier"
 
       akka.kafka.consumer {
         kafka-clients {

--- a/docs-source/docs/modules/microservices-tutorial/examples/05-shopping-cart-service-java/src/main/resources/kafka.conf
+++ b/docs-source/docs/modules/microservices-tutorial/examples/05-shopping-cart-service-java/src/main/resources/kafka.conf
@@ -1,6 +1,6 @@
 shopping-cart-service {
 
-  kafka.topic = "shopping_cart_events"
+  kafka.topic = "shopping-cart-events"
 
 }
 

--- a/docs-source/docs/modules/microservices-tutorial/examples/05-shopping-cart-service-scala/src/main/resources/kafka.conf
+++ b/docs-source/docs/modules/microservices-tutorial/examples/05-shopping-cart-service-scala/src/main/resources/kafka.conf
@@ -1,6 +1,6 @@
 shopping-cart-service {
 
-  kafka.topic = "shopping_cart_events"
+  kafka.topic = "shopping-cart-events"
 
 }
 

--- a/docs-source/docs/modules/microservices-tutorial/examples/shopping-analytics-service-java/src/main/resources/kafka.conf
+++ b/docs-source/docs/modules/microservices-tutorial/examples/shopping-analytics-service-java/src/main/resources/kafka.conf
@@ -1,5 +1,5 @@
 shopping-analytics-service {
-  shopping-cart-kafka-topic = "shopping_cart_events"
+  shopping-cart-kafka-topic = "shopping-cart-events"
 }
 
 # common config for akka.kafka.producer.kafka-clients and akka.kafka.consumer.kafka-clients

--- a/docs-source/docs/modules/microservices-tutorial/examples/shopping-analytics-service-scala/src/main/resources/kafka.conf
+++ b/docs-source/docs/modules/microservices-tutorial/examples/shopping-analytics-service-scala/src/main/resources/kafka.conf
@@ -1,5 +1,5 @@
 shopping-analytics-service {
-  shopping-cart-kafka-topic = "shopping_cart_events"
+  shopping-cart-kafka-topic = "shopping-cart-events"
 }
 
 # common config for akka.kafka.producer.kafka-clients and akka.kafka.consumer.kafka-clients

--- a/docs-source/docs/modules/microservices-tutorial/examples/shopping-cart-service-java/src/main/resources/kafka.conf
+++ b/docs-source/docs/modules/microservices-tutorial/examples/shopping-cart-service-java/src/main/resources/kafka.conf
@@ -1,6 +1,6 @@
 shopping-cart-service {
 
-  kafka.topic = "shopping_cart_events"
+  kafka.topic = "shopping-cart-events"
 
 }
 

--- a/docs-source/docs/modules/microservices-tutorial/examples/shopping-cart-service-scala/src/main/resources/kafka.conf
+++ b/docs-source/docs/modules/microservices-tutorial/examples/shopping-cart-service-scala/src/main/resources/kafka.conf
@@ -1,6 +1,6 @@
 shopping-cart-service {
 
-  kafka.topic = "shopping_cart_events"
+  kafka.topic = "shopping-cart-events"
 
 }
 


### PR DESCRIPTION
Due to limitations in metric names, topics with a period ('.') or underscore ('_') could collide

References #452
