### PR TITLE
Place anchors above titles

### DIFF
--- a/docs-source/docs/modules/concepts/pages/ddd.adoc
+++ b/docs-source/docs/modules/concepts/pages/ddd.adoc
@@ -8,8 +8,8 @@ ____
 Domain-driven design (DDD) is the concept that the structure and language of software code (class names, class methods, class variables) should match the business domain. For example, if a software processes loan applications, it might have classes such as LoanApplication and Customer, and methods such as AcceptOffer and Withdraw.
 ____
 
-== Bounded Context
 [#bounded_context]
+== Bounded Context
 
 As the modelling covers a more extensive area of your business, {reactive-principles}/patterns/partition-state.html[split the models {tab-icon}, window="tab"] into very well-delimited contexts in which each model applies. Each of these contexts will have xref:autonomy.adoc[autonomy] to evolve the models it owns.
 
@@ -19,13 +19,13 @@ A model within these bounds may need to be shared to interact with external cont
 
 When building Microservices, each service is a Bounded Context encapsulating an autonomous domain model and its external APIs play the role of an Anti-Corruption Layer.
 
-== Ubiquitous Language
 [#ubiquitous_language]
+== Ubiquitous Language
 
 Business specialists and other members of the team (both technical and non-technical) should collaborate into creating a single, meaningful naming for the use cases, entities, actions and events modelling the business. Using a single, common language will align all parties and improve communication.
 
-== Stateful Aggregate
 [#aggregate]
+== Stateful Aggregate
 
 The Aggregate is a graph of related domain objects that can only be mutated in an atomic operation. The Aggregate is responsible for keeping the invariants of the model. It decides which mutations are allowed according to its business rules and current state.
 
@@ -36,8 +36,8 @@ We can take the xref:microservices-tutorial:entity.adoc#event_sourced_entity[Sho
 All operations must pass through the Shopping Cart, so it can check its validity. You may add or remove an item, or change its quantity, you can checkout the cart. All those operations are atomic and sequential. It should not be allowed to change its content at the same time the cart is being checkout, nor it should be allowed to checkout an empty cart. The Shopping Cart Aggregate will act as the guardian of the model integrity ensuring that only valid mutations are allowed.
 
 
-== Anti-Corruption Layer
 [#anti_corruption_layer]
+== Anti-Corruption Layer
 
 Sharing entities across <<Bounded Context>>'s adds coupling since a change on the entity model affects the code consuming it. An Anti-Corruption Layer is a transformation mapping the external model (controlled by a third party bounded context) into an internal model that's stable to the actual bounded context consuming the model.
 

--- a/docs-source/docs/modules/concepts/pages/deployment-and-container-orchestration.adoc
+++ b/docs-source/docs/modules/concepts/pages/deployment-and-container-orchestration.adoc
@@ -11,14 +11,14 @@ Each step of the tutorial has instructions of how to run in Kubernetes, for exam
 
 Alternatively, you can deploy {akka-management}/kubernetes-deployment/index.html[Akka Cluster applications to Kubernetes without the Akka Platform Operator {tab-icon}, window="tab"], but that requires more expertise of Kubernetes.
 
-== Docker
 [#docker]
+== Docker
 
 Docker is a popular containerization technology. If you are unfamiliar to containers, we recommend the 
 {docker-docs}/get-started/[Get Started with Docker {tab-icon}, window="tab"] documentation.
 
-== Kubernetes
 [#kubernetes]
+== Kubernetes
 
 [quote, ,'https://en.wikipedia.org/wiki/Kubernetes[Wikipedia]']
 ____

--- a/docs-source/docs/modules/concepts/pages/event-sourcing.adoc
+++ b/docs-source/docs/modules/concepts/pages/event-sourcing.adoc
@@ -25,8 +25,8 @@ Event Sourcing improves writing performance thanks to multiple aspects:
 * The history of events for a single entity can use snapshots so reconstructing an entity with a large list of events is fast: load only the latest snapshot and apply the last few events on top.
 * Creating aggregates or other projections over multiple entities happens asynchronously to write operations producing xref:eventual-consistency.adoc[eventually consistent] representations of the data. That happens without impacting write throughput since the events Journal is an append-only table so no locking is required to ensure consistency between the journal and the projections.
 
-== Advantages of Event Sourcing
 [#advantages]
+== Advantages of Event Sourcing
 
 Event Sourcing achieves persistence by storing state changes as historical events that capture business activity. This decouples the events from the storage mechanism, allowing them to be aggregated, or placed in a group with logical boundaries. Event Sourcing is one of the patterns that enables concurrent, distributed systems to achieve high performance, scalability and resilience.
 
@@ -57,5 +57,3 @@ https://hackernoon.com/events-as-first-class-citizens-8633e8479493[Events As Fir
 * The {akka-blog}/news/2020/01/07/akka-event-sourcing-video[Event Sourcing with Akka 2.6 video {tab-icon}, window="tab"] is a good starting point for learning Event Sourcing.
 
 * {akka}/typed/persistence.html#introduction[Akka Event Sourcing documentation {tab-icon}, window="tab"].
-
-

--- a/docs-source/docs/modules/concepts/pages/memory-image-pattern.adoc
+++ b/docs-source/docs/modules/concepts/pages/memory-image-pattern.adoc
@@ -9,8 +9,8 @@ Memory Image is a programming pattern in which data stored on the database resid
 1. handling concurrent modification attempts, and 
 2. keeping the consistency across nodes running the application.
 
-== Sharded Entities
 [#sharded_entities]
+== Sharded Entities
 
 One way to meet the two requirements above is to ensure only one copy of the data is on memory at any given time. That's also known as {reactive-principles}/patterns/isolate-mutations.html[isolating the mutations {tab-icon}, window="tab"]. Then, because your data may exceed the capacity of your memory, you can shard the data and keep a chunk on each of your application nodes. Finally, each shard of data uses mutual exclusion mechanisms to ensure each mutation happens sequentially.
 

--- a/docs-source/docs/modules/concepts/pages/message-driven-event-driven.adoc
+++ b/docs-source/docs/modules/concepts/pages/message-driven-event-driven.adoc
@@ -6,8 +6,8 @@ include::partial$include.adoc[]
 [quote,'Jonas Bonér, Dave Farley, Roland Kuhn, and Martin Thompson, et al.', '{reactive-manifesto}[Reactive Manifesto {tab-icon}, window="tab"]' ]
 Reactive Systems rely on {glossary-asynchronous}[asynchronous {tab-icon}, window="tab"] {glossary-message-driven}[message-passing {tab-icon}, window="tab"] to establish a boundary between components that ensures loose coupling, isolation and {glossary-location-transparency}[location transparency {tab-icon}, window="tab"]. This boundary also provides the means to delegate {glossary-failure}[failures {tab-icon}, window="tab"] as messages. Employing explicit message-passing enables load management, elasticity, and flow control by shaping and monitoring the message queues in the system and applying {glossary-back-pressure}[back-pressure {tab-icon}, window="tab"] when necessary. Location transparent messaging as a means of communication makes it possible for the management of failure to work with the same constructs and semantics across a cluster or within a single host. {glossary-non-blocking}[Non-blocking {tab-icon}, window="tab"] communication allows recipients to only consume {glossary-resource}[resources {tab-icon}, window="tab"] while active, leading to less system overhead.
 
-== Message vs Event
 [#message_vs_event]
+== Message vs Event
 
 A Message is some data sent to a specific address. In Message Driven systems, each component has a unique address other components can send messages to. Each of these components, or recipients, awaits messages and reacts to them.
 

--- a/docs-source/docs/modules/concepts/pages/reactive-disambiguation.adoc
+++ b/docs-source/docs/modules/concepts/pages/reactive-disambiguation.adoc
@@ -14,8 +14,8 @@ Introduced in 2013, the Reactive Manifesto summarizes the properties a system mu
 
 Read the whole manifesto at {reactive-manifesto}[https://www.reactivemanifesto.org/ {tab-icon}, window="tab"].
 
-== Reactive Principles (and Patterns)
 [#reactive_principles]
+== Reactive Principles (and Patterns)
 
 [quote]
 As a companion to the <<Reactive Manifesto>>, the Reactive Principles incorporate the ideas, paradigms, methods, and patterns from both <<Reactive Programming>> and <<Reactive Systems>> into a set of practical principles that software architects and developers can apply in their transformative work.

--- a/docs-source/docs/modules/concepts/pages/services.adoc
+++ b/docs-source/docs/modules/concepts/pages/services.adoc
@@ -36,8 +36,8 @@ To ensure delivery of messages asynchronous communication may require extra meas
 
 NOTE: The xref:microservices-tutorial:projection-kafka.adoc[] in the tutorial illustrates how to use Kafka for asynchronous communication between to Microservices.
 
-== Service Discovery
 [#service-discovery]
+== Service Discovery
 
 Service Discovery is the mechanism service clients will use to locate and consume a xref:mobility.adoc[movable] service. Service Discovery is a key building block to {glossary-location-transparency}[Location Transparency {tab-icon}, window="tab"]. Service clients relying on Service Discovery no longer need to have previous knowledge of the address of a service and, instead, use a discovery mechanism any time they need to use that address.
 
@@ -52,4 +52,3 @@ With server-side Service Discovery, on the other hand, the service implementor p
 == Protecting our Service
 
 A Service may experience transient failure or degradation due to excessive load, GC pauses, etc... in that case, clients will retry the failed request, which will increase the load. Instead, in order to let the service recover from the transient failure as fast as possible, clients should use xref:circuit-breakers.adoc[Circuit Breakers].
-

--- a/docs-source/docs/modules/deployment/pages/index.adoc
+++ b/docs-source/docs/modules/deployment/pages/index.adoc
@@ -16,8 +16,8 @@ The Akka Platform Operator provides the following high level features:
 * support for gRPC and HTTP services and internet facing ingress
 * insights to deployment status
 
-== Overview of deployment procedure
 [#deployment_procedure]
+== Overview of deployment procedure
 
 === Deploying an Akka Microservices application
 
@@ -51,4 +51,3 @@ image::deployment-overview2.png[Deployment 2]
 * xref:aws-install.adoc[Installation in Amazon EKS]
 * {akka-management}/[Akka Management {tab-icon}, window="tab"] for Akka Cluster formation and health checks
 * {akka-management}/kubernetes-deployment/index.html[Deploying Akka Cluster to Kubernetes without the Akka Platform Operator {tab-icon}, window="tab"]
-

--- a/docs-source/docs/modules/microservices-tutorial/pages/dev-env.adoc
+++ b/docs-source/docs/modules/microservices-tutorial/pages/dev-env.adoc
@@ -63,8 +63,8 @@ sbt:shopping-cart-service> test
 
 The https://github.com/fullstorydev/grpcurl[grpcurl {tab-icon}, window="tab"] tool is useful for making gRPC calls from the command line. It is used in tutorial procedures and we recommend that you install it as described in https://github.com/fullstorydev/grpcurl#installation[the grpcurl documentation {tab-icon}, window="tab"].
 
-== Docker and Docker Compose
 [#docker]
+== Docker and Docker Compose
 
 See the instructions for installing https://docs.docker.com/get-docker/[Docker {tab-icon}, window="tab"] and https://docs.docker.com/compose/install/[Docker Compose {tab-icon}, window="tab"] on your platform.
 

--- a/docs-source/docs/modules/microservices-tutorial/pages/entity.adoc
+++ b/docs-source/docs/modules/microservices-tutorial/pages/entity.adoc
@@ -169,8 +169,8 @@ Scala::
 include::example$02-shopping-cart-service-scala/src/main/scala/shopping/cart/ShoppingCart.scala[tags=obj;eventHandler]
 ----
 
-== Add initialization
 [#initialization]
+== Add initialization
 
 To glue the command handler, event handler, and state together, we need some initialization code. Our code will distribute the Cart entities over nodes in the Akka Cluster with https://doc.akka.io/docs/akka/current/cluster-sharding.html[Cluster Sharding {tab-icon}, window="tab"], enable snapshots to reduce recovery time when the entity is started, and restart with backoff in the case of failure. 
 

--- a/docs-source/docs/modules/microservices-tutorial/pages/grpc-service.adoc
+++ b/docs-source/docs/modules/microservices-tutorial/pages/grpc-service.adoc
@@ -93,8 +93,8 @@ include::example$01-shopping-cart-service-scala/src/main/scala/shopping/cart/Sho
 
 <1> The method corresponding to the `rpc AddItem` in the service definition. Defined in the generated `proto.ShoppingCartService`.
 
-== Initialize HTTP Server
 [#server]
+== Initialize HTTP Server
 
 We will run the gRPC service implementation in an Akka HTTP server. Add the following server initialization code in a `ShoppingCartServer` [.group-scala]#`object`# [.group-java]#`class`#:
 

--- a/docs-source/docs/modules/microservices-tutorial/pages/projection-query.adoc
+++ b/docs-source/docs/modules/microservices-tutorial/pages/projection-query.adoc
@@ -139,8 +139,8 @@ include::example$04-shopping-cart-service-scala/src/main/scala/shopping/cart/Ite
 
 We want to connect the events from the `ShoppingCart` with the Projection. Several instances of the Projection may run on different nodes of the Akka Cluster. Each Projection instance will consume a slice of the events to distribute the load. All events from a specific entity (cart id) will always be processed by the same Projection instance so that it can build a stateful model from the events if needed.
 
-=== Create tags
 [#tagging]
+=== Create tags
 
 To connect the events from the entities with the Projection we need to tag the events. We should use several tags, each with a slice number, to distribute the events over several Projection instances. The tag is selected based on the modulo of the entity id's hash code (stable identifier) and the total number of tags. Each entity instance will tag its events using one of those tags, and the entity instance will always use the same tag.
 
@@ -195,8 +195,8 @@ include::example$04-shopping-cart-service-scala/src/main/scala/shopping/cart/Sho
 
 NOTE: In this example, we use five different tags. Tagging is not easy to change later without system downtime. Before going live in production you should consider how many tags to use, see {akka-projection}/running.html[Akka Projections reference documentation {tab-icon}, window="tab"] for more information.
 
-=== Create Projection
 [#projection]
+=== Create Projection
 
 To create the Projection:
 

--- a/docs-source/docs/modules/microservices-tutorial/pages/template.adoc
+++ b/docs-source/docs/modules/microservices-tutorial/pages/template.adoc
@@ -8,8 +8,8 @@ We provide a template so that you don't need to create the shopping cart project
 
 :sectnums:
 
-== Download the empty template
 [#seed-template]
+== Download the empty template
 
 The starting template is available as downloadable zip file with Java or Scala sources. Select your preferred language (Java/Scala):
 
@@ -47,8 +47,8 @@ sbt compile
 
 ifdef::review[REVIEWERS: we should add what they will see if successful and what to do if not.]
 
-== Open the project in IntelliJ
 [#intellij]
+== Open the project in IntelliJ
 
 If you are using IntelliJ, follow these steps to open the project:
 


### PR DESCRIPTION
Moves all anchors to above the title as discussed here: https://github.com/akka/akka-platform-guide/pull/482#discussion_r560443378

I didn't change the grpc service because PR #474 is already doing that.