### PR TITLE
Changed docker-compose down to docker-compose stop

### DIFF
--- a/docs-source/docs/modules/microservices-tutorial/pages/complete-entity.adoc
+++ b/docs-source/docs/modules/microservices-tutorial/pages/complete-entity.adoc
@@ -410,7 +410,7 @@ When finished, stop the service with `ctrl-c`. Leave PostgresSQL running for the
 
 [source,shell script]
 ----
-docker-compose down
+docker-compose stop
 ----
 
 [#kubernetes]

--- a/docs-source/docs/modules/microservices-tutorial/pages/projection-grpc-client.adoc
+++ b/docs-source/docs/modules/microservices-tutorial/pages/projection-grpc-client.adoc
@@ -293,7 +293,7 @@ When finished:
 +
 [source,shell script]
 ----
-docker-compose down
+docker-compose stop
 ----
 
 [#kubernetes]

--- a/docs-source/docs/modules/microservices-tutorial/pages/projection-kafka.adoc
+++ b/docs-source/docs/modules/microservices-tutorial/pages/projection-kafka.adoc
@@ -308,7 +308,7 @@ When finished, stop the `shopping-cart-service` and `shopping-analytics-service`
 
 [source,shell script]
 ----
-docker-compose down
+docker-compose stop
 ----
 
 [#kubernetes]

--- a/docs-source/docs/modules/microservices-tutorial/pages/projection-query.adoc
+++ b/docs-source/docs/modules/microservices-tutorial/pages/projection-query.adoc
@@ -427,7 +427,7 @@ When finished, stop the service with `ctrl-c`. Leave PostgresSQL running for the
 
 [source,shell script]
 ----
-docker-compose down
+docker-compose stop
 ----
 
 [#kubernetes]


### PR DESCRIPTION
<!--
  Are there any relevant issues / PRs / mailing lists discussions?
  Please reference them here - but don't use `fixes` notation.
-->
Changes `docker-compose down` to `docker-compose stop` in microservices tutorial to prevent removing containers