### PR TITLE
Cleanup callouts from YAML/HOCON files

### DIFF
--- a/scripts/prepare-downloads.sh
+++ b/scripts/prepare-downloads.sh
@@ -26,7 +26,7 @@ function removeTags() {
 
    ## remove call-outs ("// <3>" and "# <4>")
    find . -type f -print0 | xargs -0 sed -i "s/\/\/ <[0-9]*>//g" 
-   find . -type f -print0 | xargs -0 sed -i "s/# <[0-9]*>//g" 
+   find . -type f -print0 | xargs -0 sed -i "s/#[ ]*<[0-9]*>//g" 
 }
 
 

--- a/scripts/prepare-downloads.sh
+++ b/scripts/prepare-downloads.sh
@@ -24,8 +24,9 @@ function removeTags() {
    find . -type f -print0 | xargs -0 sed -i "s/# tag::[^\[]*\[.*\]//g"
    find . -type f -print0 | xargs -0 sed -i "s/# end::[^\[]*\[.*\]//g"
 
-   ## remove call-outs
-   find . -type f -print0 | xargs -0 sed -i "s/\/\/ <[0-9]*>//g"
+   ## remove call-outs ("// <3>" and "# <4>")
+   find . -type f -print0 | xargs -0 sed -i "s/\/\/ <[0-9]*>//g" 
+   find . -type f -print0 | xargs -0 sed -i "s/# <[0-9]*>//g" 
 }
 
 


### PR DESCRIPTION
References #497

I didn't see any use of callouts in HOCON nor YAML in `main` but this improvement doesn't harm and prepares the script for YAML and HOCON (and other formats where comments are prepended with `#`).
