### PR TITLE
remove bintray repository

### DIFF
--- a/docs-source/docs/modules/how-to/examples/shopping-cart-service-cassandra-java/pom.xml
+++ b/docs-source/docs/modules/how-to/examples/shopping-cart-service-cassandra-java/pom.xml
@@ -38,16 +38,6 @@
     </properties>
     <!-- end::akka-persistence-cassandra[] -->
 
-    <repositories>
-        <repository>
-            <id>akka-maven</id>
-            <!-- for akka-projection artifacts. 
-                 not yet published in maven central due to instability issues -->
-            <name>Akka Bintray Repository</name>
-            <url>https://dl.bintray.com/akka/maven</url>
-        </repository>
-    </repositories>
-
     <dependencyManagement>
         <dependencies>
             <dependency>

--- a/docs-source/docs/modules/how-to/examples/shopping-cart-service-cassandra-scala/build.sbt
+++ b/docs-source/docs/modules/how-to/examples/shopping-cart-service-cassandra-scala/build.sbt
@@ -34,10 +34,6 @@ dockerUsername := sys.props.get("docker.username")
 dockerRepository := sys.props.get("docker.registry")
 ThisBuild / dynverSeparator := "-"
 
-// for akka-projection artifacts
-// not yet published in maven central due to instability issues
-resolvers += Resolver.bintrayRepo("akka", "maven")
-
 // tag::akka-persistence-cassandra[]
 libraryDependencies ++= Seq(
   // end::akka-persistence-cassandra[]

--- a/docs-source/docs/modules/how-to/examples/shopping-cart-service-scala/build.sbt
+++ b/docs-source/docs/modules/how-to/examples/shopping-cart-service-scala/build.sbt
@@ -33,10 +33,6 @@ dockerUsername := sys.props.get("docker.username")
 dockerRepository := sys.props.get("docker.registry")
 ThisBuild / dynverSeparator := "-"
 
-// for akka-projection artifacts
-// not yet published in maven central due to instability issues
-resolvers += Resolver.bintrayRepo("akka", "maven")
-
 // tag::dependencies-for-healthchecks[]
 libraryDependencies ++= Seq(
 // end::dependencies-for-healthchecks[]

--- a/docs-source/docs/modules/microservices-tutorial/examples/00-shopping-analytics-service-java/pom.xml
+++ b/docs-source/docs/modules/microservices-tutorial/examples/00-shopping-analytics-service-java/pom.xml
@@ -31,16 +31,6 @@
              It can be defined with -Dversion.number=0.1-SNAPSHOT if git is not used -->
         <version.number>${git.commit.time}-${git.commit.id.abbrev}</version.number>
     </properties>
-    
-    <repositories>
-        <repository>
-            <id>akka-maven</id>
-            <!-- for akka-persistence-jdbc and akka-projection artifacts. 
-                 not yet published in maven central due to instability issues -->
-            <name>Akka Bintray Repository</name>
-            <url>https://dl.bintray.com/akka/maven</url>
-        </repository>
-    </repositories>
 
     <dependencyManagement>
         <dependencies>

--- a/docs-source/docs/modules/microservices-tutorial/examples/00-shopping-analytics-service-scala/build.sbt
+++ b/docs-source/docs/modules/microservices-tutorial/examples/00-shopping-analytics-service-scala/build.sbt
@@ -40,10 +40,6 @@ dockerUsername := sys.props.get("docker.username")
 dockerRepository := sys.props.get("docker.registry")
 ThisBuild / dynverSeparator := "-"
 
-// for akka-persistence-jdbc and akka-projection artifacts
-// not yet published in maven central due to instability issues
-resolvers += Resolver.bintrayRepo("akka", "maven")
-
 libraryDependencies ++= Seq(
   // 1. Basic dependencies for a clustered application
   "com.typesafe.akka" %% "akka-stream" % AkkaVersion,

--- a/docs-source/docs/modules/microservices-tutorial/examples/00-shopping-cart-service-java/pom.xml
+++ b/docs-source/docs/modules/microservices-tutorial/examples/00-shopping-cart-service-java/pom.xml
@@ -32,16 +32,6 @@
         <version.number>${git.commit.time}-${git.commit.id.abbrev}</version.number>
     </properties>
 
-    <repositories>
-        <repository>
-            <id>akka-maven</id>
-            <!-- for akka-persistence-jdbc and akka-projection artifacts. 
-                 not yet published in maven central due to instability issues -->
-            <name>Akka Bintray Repository</name>
-            <url>https://dl.bintray.com/akka/maven</url>
-        </repository>
-    </repositories>
-
     <dependencyManagement>
         <dependencies>
             <dependency>

--- a/docs-source/docs/modules/microservices-tutorial/examples/00-shopping-cart-service-scala/build.sbt
+++ b/docs-source/docs/modules/microservices-tutorial/examples/00-shopping-cart-service-scala/build.sbt
@@ -40,10 +40,6 @@ dockerUsername := sys.props.get("docker.username")
 dockerRepository := sys.props.get("docker.registry")
 ThisBuild / dynverSeparator := "-"
 
-// for akka-persistence-jdbc and akka-projection artifacts
-// not yet published in maven central due to instability issues
-resolvers += Resolver.bintrayRepo("akka", "maven")
-
 libraryDependencies ++= Seq(
   // 1. Basic dependencies for a clustered application
   "com.typesafe.akka" %% "akka-stream" % AkkaVersion,

--- a/docs-source/docs/modules/microservices-tutorial/examples/00-shopping-order-service-java/pom.xml
+++ b/docs-source/docs/modules/microservices-tutorial/examples/00-shopping-order-service-java/pom.xml
@@ -32,16 +32,6 @@
         <version.number>${git.commit.time}-${git.commit.id.abbrev}</version.number>
     </properties>
 
-    <repositories>
-        <repository>
-            <id>akka-maven</id>
-            <!-- for akka-persistence-jdbc and akka-projection artifacts. 
-                 not yet published in maven central due to instability issues -->
-            <name>Akka Bintray Repository</name>
-            <url>https://dl.bintray.com/akka/maven</url>
-        </repository>
-    </repositories>
-
     <dependencyManagement>
         <dependencies>
             <dependency>

--- a/docs-source/docs/modules/microservices-tutorial/examples/00-shopping-order-service-scala/build.sbt
+++ b/docs-source/docs/modules/microservices-tutorial/examples/00-shopping-order-service-scala/build.sbt
@@ -40,10 +40,6 @@ dockerUsername := sys.props.get("docker.username")
 dockerRepository := sys.props.get("docker.registry")
 ThisBuild / dynverSeparator := "-"
 
-// for akka-persistence-jdbc and akka-projection artifacts
-// not yet published in maven central due to instability issues
-resolvers += Resolver.bintrayRepo("akka", "maven")
-
 libraryDependencies ++= Seq(
   // 1. Basic dependencies for a clustered application
   "com.typesafe.akka" %% "akka-stream" % AkkaVersion,

--- a/docs-source/docs/modules/microservices-tutorial/examples/01-shopping-cart-service-java/pom.xml
+++ b/docs-source/docs/modules/microservices-tutorial/examples/01-shopping-cart-service-java/pom.xml
@@ -32,16 +32,6 @@
         <version.number>${git.commit.time}-${git.commit.id.abbrev}</version.number>
     </properties>
 
-    <repositories>
-        <repository>
-            <id>akka-maven</id>
-            <!-- for akka-persistence-jdbc and akka-projection artifacts. 
-                 not yet published in maven central due to instability issues -->
-            <name>Akka Bintray Repository</name>
-            <url>https://dl.bintray.com/akka/maven</url>
-        </repository>
-    </repositories>
-
     <dependencyManagement>
         <dependencies>
             <dependency>

--- a/docs-source/docs/modules/microservices-tutorial/examples/01-shopping-cart-service-scala/build.sbt
+++ b/docs-source/docs/modules/microservices-tutorial/examples/01-shopping-cart-service-scala/build.sbt
@@ -40,10 +40,6 @@ dockerUsername := sys.props.get("docker.username")
 dockerRepository := sys.props.get("docker.registry")
 ThisBuild / dynverSeparator := "-"
 
-// for akka-persistence-jdbc and akka-projection artifacts
-// not yet published in maven central due to instability issues
-resolvers += Resolver.bintrayRepo("akka", "maven")
-
 libraryDependencies ++= Seq(
   // 1. Basic dependencies for a clustered application
   "com.typesafe.akka" %% "akka-stream" % AkkaVersion,

--- a/docs-source/docs/modules/microservices-tutorial/examples/02-shopping-cart-service-java/pom.xml
+++ b/docs-source/docs/modules/microservices-tutorial/examples/02-shopping-cart-service-java/pom.xml
@@ -32,16 +32,6 @@
         <version.number>${git.commit.time}-${git.commit.id.abbrev}</version.number>
     </properties>
 
-    <repositories>
-        <repository>
-            <id>akka-maven</id>
-            <!-- for akka-persistence-jdbc and akka-projection artifacts. 
-                 not yet published in maven central due to instability issues -->
-            <name>Akka Bintray Repository</name>
-            <url>https://dl.bintray.com/akka/maven</url>
-        </repository>
-    </repositories>
-
     <dependencyManagement>
         <dependencies>
             <dependency>

--- a/docs-source/docs/modules/microservices-tutorial/examples/02-shopping-cart-service-scala/build.sbt
+++ b/docs-source/docs/modules/microservices-tutorial/examples/02-shopping-cart-service-scala/build.sbt
@@ -40,10 +40,6 @@ dockerUsername := sys.props.get("docker.username")
 dockerRepository := sys.props.get("docker.registry")
 ThisBuild / dynverSeparator := "-"
 
-// for akka-persistence-jdbc and akka-projection artifacts
-// not yet published in maven central due to instability issues
-resolvers += Resolver.bintrayRepo("akka", "maven")
-
 libraryDependencies ++= Seq(
   // 1. Basic dependencies for a clustered application
   "com.typesafe.akka" %% "akka-stream" % AkkaVersion,

--- a/docs-source/docs/modules/microservices-tutorial/examples/03-shopping-cart-service-java/pom.xml
+++ b/docs-source/docs/modules/microservices-tutorial/examples/03-shopping-cart-service-java/pom.xml
@@ -32,16 +32,6 @@
         <version.number>${git.commit.time}-${git.commit.id.abbrev}</version.number>
     </properties>
 
-    <repositories>
-        <repository>
-            <id>akka-maven</id>
-            <!-- for akka-persistence-jdbc and akka-projection artifacts. 
-                 not yet published in maven central due to instability issues -->
-            <name>Akka Bintray Repository</name>
-            <url>https://dl.bintray.com/akka/maven</url>
-        </repository>
-    </repositories>
-
     <dependencyManagement>
         <dependencies>
             <dependency>

--- a/docs-source/docs/modules/microservices-tutorial/examples/03-shopping-cart-service-scala/build.sbt
+++ b/docs-source/docs/modules/microservices-tutorial/examples/03-shopping-cart-service-scala/build.sbt
@@ -40,10 +40,6 @@ dockerUsername := sys.props.get("docker.username")
 dockerRepository := sys.props.get("docker.registry")
 ThisBuild / dynverSeparator := "-"
 
-// for akka-persistence-jdbc and akka-projection artifacts
-// not yet published in maven central due to instability issues
-resolvers += Resolver.bintrayRepo("akka", "maven")
-
 libraryDependencies ++= Seq(
   // 1. Basic dependencies for a clustered application
   "com.typesafe.akka" %% "akka-stream" % AkkaVersion,

--- a/docs-source/docs/modules/microservices-tutorial/examples/04-shopping-cart-service-java/pom.xml
+++ b/docs-source/docs/modules/microservices-tutorial/examples/04-shopping-cart-service-java/pom.xml
@@ -32,16 +32,6 @@
         <version.number>${git.commit.time}-${git.commit.id.abbrev}</version.number>
     </properties>
 
-    <repositories>
-        <repository>
-            <id>akka-maven</id>
-            <!-- for akka-persistence-jdbc and akka-projection artifacts. 
-                 not yet published in maven central due to instability issues -->
-            <name>Akka Bintray Repository</name>
-            <url>https://dl.bintray.com/akka/maven</url>
-        </repository>
-    </repositories>
-
     <dependencyManagement>
         <dependencies>
             <dependency>

--- a/docs-source/docs/modules/microservices-tutorial/examples/04-shopping-cart-service-scala/build.sbt
+++ b/docs-source/docs/modules/microservices-tutorial/examples/04-shopping-cart-service-scala/build.sbt
@@ -40,10 +40,6 @@ dockerUsername := sys.props.get("docker.username")
 dockerRepository := sys.props.get("docker.registry")
 ThisBuild / dynverSeparator := "-"
 
-// for akka-persistence-jdbc and akka-projection artifacts
-// not yet published in maven central due to instability issues
-resolvers += Resolver.bintrayRepo("akka", "maven")
-
 libraryDependencies ++= Seq(
   // 1. Basic dependencies for a clustered application
   "com.typesafe.akka" %% "akka-stream" % AkkaVersion,

--- a/docs-source/docs/modules/microservices-tutorial/examples/05-shopping-cart-service-java/pom.xml
+++ b/docs-source/docs/modules/microservices-tutorial/examples/05-shopping-cart-service-java/pom.xml
@@ -32,16 +32,6 @@
         <version.number>${git.commit.time}-${git.commit.id.abbrev}</version.number>
     </properties>
 
-    <repositories>
-        <repository>
-            <id>akka-maven</id>
-            <!-- for akka-persistence-jdbc and akka-projection artifacts. 
-                 not yet published in maven central due to instability issues -->
-            <name>Akka Bintray Repository</name>
-            <url>https://dl.bintray.com/akka/maven</url>
-        </repository>
-    </repositories>
-
     <dependencyManagement>
         <dependencies>
             <dependency>

--- a/docs-source/docs/modules/microservices-tutorial/examples/05-shopping-cart-service-scala/build.sbt
+++ b/docs-source/docs/modules/microservices-tutorial/examples/05-shopping-cart-service-scala/build.sbt
@@ -40,10 +40,6 @@ dockerUsername := sys.props.get("docker.username")
 dockerRepository := sys.props.get("docker.registry")
 ThisBuild / dynverSeparator := "-"
 
-// for akka-persistence-jdbc and akka-projection artifacts
-// not yet published in maven central due to instability issues
-resolvers += Resolver.bintrayRepo("akka", "maven")
-
 libraryDependencies ++= Seq(
   // 1. Basic dependencies for a clustered application
   "com.typesafe.akka" %% "akka-stream" % AkkaVersion,

--- a/docs-source/docs/modules/microservices-tutorial/examples/shopping-analytics-service-java/pom.xml
+++ b/docs-source/docs/modules/microservices-tutorial/examples/shopping-analytics-service-java/pom.xml
@@ -31,16 +31,6 @@
              It can be defined with -Dversion.number=0.1-SNAPSHOT if git is not used -->
         <version.number>${git.commit.time}-${git.commit.id.abbrev}</version.number>
     </properties>
-    
-    <repositories>
-        <repository>
-            <id>akka-maven</id>
-            <!-- for akka-persistence-jdbc and akka-projection artifacts. 
-                 not yet published in maven central due to instability issues -->
-            <name>Akka Bintray Repository</name>
-            <url>https://dl.bintray.com/akka/maven</url>
-        </repository>
-    </repositories>
 
     <dependencyManagement>
         <dependencies>

--- a/docs-source/docs/modules/microservices-tutorial/examples/shopping-analytics-service-scala/build.sbt
+++ b/docs-source/docs/modules/microservices-tutorial/examples/shopping-analytics-service-scala/build.sbt
@@ -40,10 +40,6 @@ dockerUsername := sys.props.get("docker.username")
 dockerRepository := sys.props.get("docker.registry")
 ThisBuild / dynverSeparator := "-"
 
-// for akka-persistence-jdbc and akka-projection artifacts
-// not yet published in maven central due to instability issues
-resolvers += Resolver.bintrayRepo("akka", "maven")
-
 libraryDependencies ++= Seq(
   // 1. Basic dependencies for a clustered application
   "com.typesafe.akka" %% "akka-stream" % AkkaVersion,

--- a/docs-source/docs/modules/microservices-tutorial/examples/shopping-cart-service-java/pom.xml
+++ b/docs-source/docs/modules/microservices-tutorial/examples/shopping-cart-service-java/pom.xml
@@ -32,16 +32,6 @@
         <version.number>${git.commit.time}-${git.commit.id.abbrev}</version.number>
     </properties>
 
-    <repositories>
-        <repository>
-            <id>akka-maven</id>
-            <!-- for akka-persistence-jdbc and akka-projection artifacts. 
-                 not yet published in maven central due to instability issues -->
-            <name>Akka Bintray Repository</name>
-            <url>https://dl.bintray.com/akka/maven</url>
-        </repository>
-    </repositories>
-
     <dependencyManagement>
         <dependencies>
             <dependency>

--- a/docs-source/docs/modules/microservices-tutorial/examples/shopping-cart-service-scala/build.sbt
+++ b/docs-source/docs/modules/microservices-tutorial/examples/shopping-cart-service-scala/build.sbt
@@ -40,10 +40,6 @@ dockerUsername := sys.props.get("docker.username")
 dockerRepository := sys.props.get("docker.registry")
 ThisBuild / dynverSeparator := "-"
 
-// for akka-persistence-jdbc and akka-projection artifacts
-// not yet published in maven central due to instability issues
-resolvers += Resolver.bintrayRepo("akka", "maven")
-
 libraryDependencies ++= Seq(
   // 1. Basic dependencies for a clustered application
   "com.typesafe.akka" %% "akka-stream" % AkkaVersion,

--- a/docs-source/docs/modules/microservices-tutorial/examples/shopping-order-service-java/pom.xml
+++ b/docs-source/docs/modules/microservices-tutorial/examples/shopping-order-service-java/pom.xml
@@ -32,16 +32,6 @@
         <version.number>${git.commit.time}-${git.commit.id.abbrev}</version.number>
     </properties>
 
-    <repositories>
-        <repository>
-            <id>akka-maven</id>
-            <!-- for akka-persistence-jdbc and akka-projection artifacts. 
-                 not yet published in maven central due to instability issues -->
-            <name>Akka Bintray Repository</name>
-            <url>https://dl.bintray.com/akka/maven</url>
-        </repository>
-    </repositories>
-
     <dependencyManagement>
         <dependencies>
             <dependency>

--- a/docs-source/docs/modules/microservices-tutorial/examples/shopping-order-service-scala/build.sbt
+++ b/docs-source/docs/modules/microservices-tutorial/examples/shopping-order-service-scala/build.sbt
@@ -40,10 +40,6 @@ dockerUsername := sys.props.get("docker.username")
 dockerRepository := sys.props.get("docker.registry")
 ThisBuild / dynverSeparator := "-"
 
-// for akka-persistence-jdbc and akka-projection artifacts
-// not yet published in maven central due to instability issues
-resolvers += Resolver.bintrayRepo("akka", "maven")
-
 libraryDependencies ++= Seq(
   // 1. Basic dependencies for a clustered application
   "com.typesafe.akka" %% "akka-stream" % AkkaVersion,


### PR DESCRIPTION
New releases are now published in Maven Central. No need to add Akka's Bintray repo. 