### PR TITLE
fix missing SIGTERM: use exec format in docker-maven-plugin

### DIFF
--- a/docs-source/docs/modules/how-to/examples/shopping-cart-service-cassandra-java/pom.xml
+++ b/docs-source/docs/modules/how-to/examples/shopping-cart-service-cassandra-java/pom.xml
@@ -276,7 +276,12 @@
                                     <tag>${version.number}</tag>
                                 </tags>
                                 <entryPoint>
-                                    java $JAVA_OPTS -cp '/maven/*' shopping.cart.Main
+                                    <exec>
+                                        <arg>java</arg>
+                                        <arg>-cp</arg>
+                                        <arg>/maven/*</arg>
+                                        <arg>shopping.cart.Main</arg>
+                                    </exec>
                                 </entryPoint>
                                 <assembly>
                                     <descriptorRef>artifact-with-dependencies</descriptorRef>

--- a/docs-source/docs/modules/microservices-tutorial/examples/00-shopping-analytics-service-java/pom.xml
+++ b/docs-source/docs/modules/microservices-tutorial/examples/00-shopping-analytics-service-java/pom.xml
@@ -279,7 +279,12 @@
                                     <tag>${version.number}</tag>
                                 </tags>
                                 <entryPoint>
-                                    java $JAVA_OPTS -cp '/maven/*' shopping.analytics.Main
+                                    <exec>
+                                        <arg>java</arg>
+                                        <arg>-cp</arg>
+                                        <arg>/maven/*</arg>
+                                        <arg>shopping.analytics.Main</arg>
+                                    </exec>
                                 </entryPoint>
                                 <assembly>
                                     <descriptorRef>artifact-with-dependencies</descriptorRef>

--- a/docs-source/docs/modules/microservices-tutorial/examples/00-shopping-cart-service-java/pom.xml
+++ b/docs-source/docs/modules/microservices-tutorial/examples/00-shopping-cart-service-java/pom.xml
@@ -279,7 +279,12 @@
                                     <tag>${version.number}</tag>
                                 </tags>
                                 <entryPoint>
-                                    java $JAVA_OPTS -cp '/maven/*' shopping.cart.Main
+                                    <exec>
+                                        <arg>java</arg>
+                                        <arg>-cp</arg>
+                                        <arg>/maven/*</arg>
+                                        <arg>shopping.cart.Main</arg>
+                                    </exec>
                                 </entryPoint>
                                 <assembly>
                                     <descriptorRef>artifact-with-dependencies</descriptorRef>

--- a/docs-source/docs/modules/microservices-tutorial/examples/00-shopping-order-service-java/pom.xml
+++ b/docs-source/docs/modules/microservices-tutorial/examples/00-shopping-order-service-java/pom.xml
@@ -279,7 +279,12 @@
                                     <tag>${version.number}</tag>
                                 </tags>
                                 <entryPoint>
-                                    java $JAVA_OPTS -cp '/maven/*' shopping.order.Main
+                                    <exec>
+                                        <arg>java</arg>
+                                        <arg>-cp</arg>
+                                        <arg>/maven/*</arg>
+                                        <arg>shopping.order.Main</arg>
+                                    </exec>
                                 </entryPoint>
                                 <assembly>
                                     <descriptorRef>artifact-with-dependencies</descriptorRef>

--- a/docs-source/docs/modules/microservices-tutorial/examples/01-shopping-cart-service-java/pom.xml
+++ b/docs-source/docs/modules/microservices-tutorial/examples/01-shopping-cart-service-java/pom.xml
@@ -279,7 +279,12 @@
                                     <tag>${version.number}</tag>
                                 </tags>
                                 <entryPoint>
-                                    java $JAVA_OPTS -cp '/maven/*' shopping.cart.Main
+                                    <exec>
+                                        <arg>java</arg>
+                                        <arg>-cp</arg>
+                                        <arg>/maven/*</arg>
+                                        <arg>shopping.cart.Main</arg>
+                                    </exec>
                                 </entryPoint>
                                 <assembly>
                                     <descriptorRef>artifact-with-dependencies</descriptorRef>

--- a/docs-source/docs/modules/microservices-tutorial/examples/02-shopping-cart-service-java/pom.xml
+++ b/docs-source/docs/modules/microservices-tutorial/examples/02-shopping-cart-service-java/pom.xml
@@ -279,7 +279,12 @@
                                     <tag>${version.number}</tag>
                                 </tags>
                                 <entryPoint>
-                                    java $JAVA_OPTS -cp '/maven/*' shopping.cart.Main
+                                    <exec>
+                                        <arg>java</arg>
+                                        <arg>-cp</arg>
+                                        <arg>/maven/*</arg>
+                                        <arg>shopping.cart.Main</arg>
+                                    </exec>
                                 </entryPoint>
                                 <assembly>
                                     <descriptorRef>artifact-with-dependencies</descriptorRef>

--- a/docs-source/docs/modules/microservices-tutorial/examples/03-shopping-cart-service-java/pom.xml
+++ b/docs-source/docs/modules/microservices-tutorial/examples/03-shopping-cart-service-java/pom.xml
@@ -279,7 +279,12 @@
                                     <tag>${version.number}</tag>
                                 </tags>
                                 <entryPoint>
-                                    java $JAVA_OPTS -cp '/maven/*' shopping.cart.Main
+                                    <exec>
+                                        <arg>java</arg>
+                                        <arg>-cp</arg>
+                                        <arg>/maven/*</arg>
+                                        <arg>shopping.cart.Main</arg>
+                                    </exec>
                                 </entryPoint>
                                 <assembly>
                                     <descriptorRef>artifact-with-dependencies</descriptorRef>

--- a/docs-source/docs/modules/microservices-tutorial/examples/04-shopping-cart-service-java/pom.xml
+++ b/docs-source/docs/modules/microservices-tutorial/examples/04-shopping-cart-service-java/pom.xml
@@ -279,7 +279,12 @@
                                     <tag>${version.number}</tag>
                                 </tags>
                                 <entryPoint>
-                                    java $JAVA_OPTS -cp '/maven/*' shopping.cart.Main
+                                    <exec>
+                                        <arg>java</arg>
+                                        <arg>-cp</arg>
+                                        <arg>/maven/*</arg>
+                                        <arg>shopping.cart.Main</arg>
+                                    </exec>
                                 </entryPoint>
                                 <assembly>
                                     <descriptorRef>artifact-with-dependencies</descriptorRef>

--- a/docs-source/docs/modules/microservices-tutorial/examples/05-shopping-cart-service-java/pom.xml
+++ b/docs-source/docs/modules/microservices-tutorial/examples/05-shopping-cart-service-java/pom.xml
@@ -279,7 +279,12 @@
                                     <tag>${version.number}</tag>
                                 </tags>
                                 <entryPoint>
-                                    java $JAVA_OPTS -cp '/maven/*' shopping.cart.Main
+                                    <exec>
+                                        <arg>java</arg>
+                                        <arg>-cp</arg>
+                                        <arg>/maven/*</arg>
+                                        <arg>shopping.cart.Main</arg>
+                                    </exec>
                                 </entryPoint>
                                 <assembly>
                                     <descriptorRef>artifact-with-dependencies</descriptorRef>

--- a/docs-source/docs/modules/microservices-tutorial/examples/shopping-analytics-service-java/pom.xml
+++ b/docs-source/docs/modules/microservices-tutorial/examples/shopping-analytics-service-java/pom.xml
@@ -279,7 +279,12 @@
                                     <tag>${version.number}</tag>
                                 </tags>
                                 <entryPoint>
-                                    java $JAVA_OPTS -cp '/maven/*' shopping.analytics.Main
+                                    <exec>
+                                        <arg>java</arg>
+                                        <arg>-cp</arg>
+                                        <arg>/maven/*</arg>
+                                        <arg>shopping.analytics.Main</arg>
+                                    </exec>
                                 </entryPoint>
                                 <assembly>
                                     <descriptorRef>artifact-with-dependencies</descriptorRef>

--- a/docs-source/docs/modules/microservices-tutorial/examples/shopping-cart-service-java/pom.xml
+++ b/docs-source/docs/modules/microservices-tutorial/examples/shopping-cart-service-java/pom.xml
@@ -279,7 +279,12 @@
                                     <tag>${version.number}</tag>
                                 </tags>
                                 <entryPoint>
-                                    java $JAVA_OPTS -cp '/maven/*' shopping.cart.Main
+                                    <exec>
+                                        <arg>java</arg>
+                                        <arg>-cp</arg>
+                                        <arg>/maven/*</arg>
+                                        <arg>shopping.cart.Main</arg>
+                                    </exec>
                                 </entryPoint>
                                 <assembly>
                                     <descriptorRef>artifact-with-dependencies</descriptorRef>

--- a/docs-source/docs/modules/microservices-tutorial/examples/shopping-order-service-java/pom.xml
+++ b/docs-source/docs/modules/microservices-tutorial/examples/shopping-order-service-java/pom.xml
@@ -279,7 +279,12 @@
                                     <tag>${version.number}</tag>
                                 </tags>
                                 <entryPoint>
-                                    java $JAVA_OPTS -cp '/maven/*' shopping.order.Main
+                                    <exec>
+                                        <arg>java</arg>
+                                        <arg>-cp</arg>
+                                        <arg>/maven/*</arg>
+                                        <arg>shopping.order.Main</arg>
+                                    </exec>
                                 </entryPoint>
                                 <assembly>
                                     <descriptorRef>artifact-with-dependencies</descriptorRef>


### PR DESCRIPTION
Causing CoordinatedShutdown and graceful leaving to not run.

docs for reference https://dmp.fabric8.io/#misc-startup

previously it was running:
```
root           1  0.0  0.0   2612   476 ?        Ss   12:29   0:00 /bin/sh -c java $JAVA_OPTS -cp '/maven/*' shopping.order.Main
root           6 11.1  6.0 4705304 244124 ?      Sl   12:29   0:25 java -cp /maven/* shopping.order.Main
```

now it's:
```
root           1 23.9  5.5 4437000 222844 ?      Ssl  12:47   0:15 java -cp /maven/* shopping.order.Main
```
