### PR TITLE
Minor improvements on JDBC samples

### DIFF
--- a/docs-source/docs/modules/microservices-tutorial/examples/00-shopping-cart-service-java/src/main/java/shopping/cart/repository/SpringConfig.java
+++ b/docs-source/docs/modules/microservices-tutorial/examples/00-shopping-cart-service-java/src/main/java/shopping/cart/repository/SpringConfig.java
@@ -70,24 +70,27 @@ public class SpringConfig {
 
     HikariDataSource dataSource = new HikariDataSource();
 
+    Config jdbcConfig = jdbcConfig();
+
     // pool configuration
     dataSource.setPoolName("read-side-connection-pool");
-    dataSource.setMaximumPoolSize(
-        config.getInt("jdbc-connection-settings.connection-pool.max-pool-size"));
+    dataSource.setMaximumPoolSize(jdbcConfig.getInt("connection-pool.max-pool-size"));
 
-    long timeout =
-        config.getDuration(
-            "jdbc-connection-settings.connection-pool.timeout", TimeUnit.MILLISECONDS);
+    long timeout = jdbcConfig.getDuration("connection-pool.timeout", TimeUnit.MILLISECONDS);
     dataSource.setConnectionTimeout(timeout);
 
     // database configuration
-    dataSource.setDriverClassName(config.getString("jdbc-connection-settings.driver"));
-    dataSource.setJdbcUrl(config.getString("jdbc-connection-settings.url"));
-    dataSource.setUsername(config.getString("jdbc-connection-settings.user"));
-    dataSource.setPassword(config.getString("jdbc-connection-settings.password"));
+    dataSource.setDriverClassName(jdbcConfig.getString("driver"));
+    dataSource.setJdbcUrl(jdbcConfig.getString("url"));
+    dataSource.setUsername(jdbcConfig.getString("user"));
+    dataSource.setPassword(jdbcConfig.getString("password"));
     dataSource.setAutoCommit(false);
 
     return dataSource;
+  }
+
+  private Config jdbcConfig() {
+    return config.getConfig("jdbc-connection-settings");
   }
 
   /**
@@ -98,8 +101,7 @@ public class SpringConfig {
   Properties additionalProperties() {
     Properties properties = new Properties();
 
-    Config additionalProperties =
-        this.config.getConfig("jdbc-connection-settings.additional-properties");
+    Config additionalProperties = jdbcConfig().getConfig("additional-properties");
     Set<Map.Entry<String, ConfigValue>> entries = additionalProperties.entrySet();
 
     for (Map.Entry<String, ConfigValue> entry : entries) {

--- a/docs-source/docs/modules/microservices-tutorial/examples/00-shopping-cart-service-scala/src/main/scala/shopping/cart/repository/ScalikeJdbcSetup.scala
+++ b/docs-source/docs/modules/microservices-tutorial/examples/00-shopping-cart-service-scala/src/main/scala/shopping/cart/repository/ScalikeJdbcSetup.scala
@@ -31,7 +31,7 @@ object ScalikeJdbcSetup {
    * Builds a Hikari DataSource with values from jdbc-connection-settings.
    * The DataSource is then configured as the 'default' connection pool for ScalikeJDBC.
    */
-  def fromConfig(config: Config): Unit = {
+  private def fromConfig(config: Config): Unit = {
 
     val dbs = new DBsFromConfig(config)
     dbs.loadGlobalSettings()

--- a/docs-source/docs/modules/microservices-tutorial/examples/00-shopping-cart-service-scala/src/main/scala/shopping/cart/repository/ScalikeJdbcSetup.scala
+++ b/docs-source/docs/modules/microservices-tutorial/examples/00-shopping-cart-service-scala/src/main/scala/shopping/cart/repository/ScalikeJdbcSetup.scala
@@ -20,7 +20,7 @@ object ScalikeJdbcSetup {
    * The connection pool will be closed when the actor system terminates.
    */
   def init(system: ActorSystem[_]): Unit = {
-    fromConfig(system.settings.config)
+    initFromConfig(system.settings.config)
     system.whenTerminated.map { _ =>
       ConnectionPool.closeAll()
     }(scala.concurrent.ExecutionContext.Implicits.global)
@@ -31,7 +31,7 @@ object ScalikeJdbcSetup {
    * Builds a Hikari DataSource with values from jdbc-connection-settings.
    * The DataSource is then configured as the 'default' connection pool for ScalikeJDBC.
    */
-  private def fromConfig(config: Config): Unit = {
+  private def initFromConfig(config: Config): Unit = {
 
     val dbs = new DBsFromConfig(config)
     dbs.loadGlobalSettings()

--- a/docs-source/docs/modules/microservices-tutorial/examples/00-shopping-cart-service-scala/src/main/scala/shopping/cart/repository/ScalikeJdbcSetup.scala
+++ b/docs-source/docs/modules/microservices-tutorial/examples/00-shopping-cart-service-scala/src/main/scala/shopping/cart/repository/ScalikeJdbcSetup.scala
@@ -36,29 +36,31 @@ object ScalikeJdbcSetup {
     val dbs = new DBsFromConfig(config)
     dbs.loadGlobalSettings()
 
-    val dataSource = new HikariDataSource()
-
-    dataSource.setPoolName("read-side-connection-pool")
-    dataSource.setMaximumPoolSize(
-      config.getInt("jdbc-connection-settings.connection-pool.max-pool-size"))
-
-    val timeout =
-      config
-        .getDuration("jdbc-connection-settings.connection-pool.timeout")
-        .toMillis
-    dataSource.setConnectionTimeout(timeout)
-
-    dataSource.setDriverClassName(
-      config.getString("jdbc-connection-settings.driver"))
-    dataSource.setJdbcUrl(config.getString("jdbc-connection-settings.url"))
-    dataSource.setUsername(config.getString("jdbc-connection-settings.user"))
-    dataSource.setPassword(
-      config.getString("jdbc-connection-settings.password"))
+    val dataSource = buildDataSource(
+      config.getConfig("jdbc-connection-settings"))
 
     ConnectionPool.singleton(
       new DataSourceConnectionPool(
         dataSource = dataSource,
         closer = HikariCloser(dataSource)))
+  }
+
+  private def buildDataSource(config: Config): HikariDataSource = {
+    val dataSource = new HikariDataSource()
+
+    dataSource.setPoolName("read-side-connection-pool")
+    dataSource.setMaximumPoolSize(
+      config.getInt("connection-pool.max-pool-size"))
+
+    val timeout = config.getDuration("connection-pool.timeout").toMillis
+    dataSource.setConnectionTimeout(timeout)
+
+    dataSource.setDriverClassName(config.getString("driver"))
+    dataSource.setJdbcUrl(config.getString("url"))
+    dataSource.setUsername(config.getString("user"))
+    dataSource.setPassword(config.getString("password"))
+
+    dataSource
   }
 
   /**

--- a/docs-source/docs/modules/microservices-tutorial/examples/01-shopping-cart-service-java/src/main/java/shopping/cart/repository/SpringConfig.java
+++ b/docs-source/docs/modules/microservices-tutorial/examples/01-shopping-cart-service-java/src/main/java/shopping/cart/repository/SpringConfig.java
@@ -70,24 +70,27 @@ public class SpringConfig {
 
     HikariDataSource dataSource = new HikariDataSource();
 
+    Config jdbcConfig = jdbcConfig();
+
     // pool configuration
     dataSource.setPoolName("read-side-connection-pool");
-    dataSource.setMaximumPoolSize(
-        config.getInt("jdbc-connection-settings.connection-pool.max-pool-size"));
+    dataSource.setMaximumPoolSize(jdbcConfig.getInt("connection-pool.max-pool-size"));
 
-    long timeout =
-        config.getDuration(
-            "jdbc-connection-settings.connection-pool.timeout", TimeUnit.MILLISECONDS);
+    long timeout = jdbcConfig.getDuration("connection-pool.timeout", TimeUnit.MILLISECONDS);
     dataSource.setConnectionTimeout(timeout);
 
     // database configuration
-    dataSource.setDriverClassName(config.getString("jdbc-connection-settings.driver"));
-    dataSource.setJdbcUrl(config.getString("jdbc-connection-settings.url"));
-    dataSource.setUsername(config.getString("jdbc-connection-settings.user"));
-    dataSource.setPassword(config.getString("jdbc-connection-settings.password"));
+    dataSource.setDriverClassName(jdbcConfig.getString("driver"));
+    dataSource.setJdbcUrl(jdbcConfig.getString("url"));
+    dataSource.setUsername(jdbcConfig.getString("user"));
+    dataSource.setPassword(jdbcConfig.getString("password"));
     dataSource.setAutoCommit(false);
 
     return dataSource;
+  }
+
+  private Config jdbcConfig() {
+    return config.getConfig("jdbc-connection-settings");
   }
 
   /**
@@ -98,8 +101,7 @@ public class SpringConfig {
   Properties additionalProperties() {
     Properties properties = new Properties();
 
-    Config additionalProperties =
-        this.config.getConfig("jdbc-connection-settings.additional-properties");
+    Config additionalProperties = jdbcConfig().getConfig("additional-properties");
     Set<Map.Entry<String, ConfigValue>> entries = additionalProperties.entrySet();
 
     for (Map.Entry<String, ConfigValue> entry : entries) {

--- a/docs-source/docs/modules/microservices-tutorial/examples/01-shopping-cart-service-scala/src/main/scala/shopping/cart/repository/ScalikeJdbcSetup.scala
+++ b/docs-source/docs/modules/microservices-tutorial/examples/01-shopping-cart-service-scala/src/main/scala/shopping/cart/repository/ScalikeJdbcSetup.scala
@@ -20,7 +20,7 @@ object ScalikeJdbcSetup {
    * The connection pool will be closed when the actor system terminates.
    */
   def init(system: ActorSystem[_]): Unit = {
-    fromConfig(system.settings.config)
+    initFromConfig(system.settings.config)
     system.whenTerminated.map { _ =>
       ConnectionPool.closeAll()
     }(scala.concurrent.ExecutionContext.Implicits.global)
@@ -31,34 +31,36 @@ object ScalikeJdbcSetup {
    * Builds a Hikari DataSource with values from jdbc-connection-settings.
    * The DataSource is then configured as the 'default' connection pool for ScalikeJDBC.
    */
-  def fromConfig(config: Config): Unit = {
+  private def initFromConfig(config: Config): Unit = {
 
     val dbs = new DBsFromConfig(config)
     dbs.loadGlobalSettings()
 
-    val dataSource = new HikariDataSource()
-
-    dataSource.setPoolName("read-side-connection-pool")
-    dataSource.setMaximumPoolSize(
-      config.getInt("jdbc-connection-settings.connection-pool.max-pool-size"))
-
-    val timeout =
-      config
-        .getDuration("jdbc-connection-settings.connection-pool.timeout")
-        .toMillis
-    dataSource.setConnectionTimeout(timeout)
-
-    dataSource.setDriverClassName(
-      config.getString("jdbc-connection-settings.driver"))
-    dataSource.setJdbcUrl(config.getString("jdbc-connection-settings.url"))
-    dataSource.setUsername(config.getString("jdbc-connection-settings.user"))
-    dataSource.setPassword(
-      config.getString("jdbc-connection-settings.password"))
+    val dataSource = buildDataSource(
+      config.getConfig("jdbc-connection-settings"))
 
     ConnectionPool.singleton(
       new DataSourceConnectionPool(
         dataSource = dataSource,
         closer = HikariCloser(dataSource)))
+  }
+
+  private def buildDataSource(config: Config): HikariDataSource = {
+    val dataSource = new HikariDataSource()
+
+    dataSource.setPoolName("read-side-connection-pool")
+    dataSource.setMaximumPoolSize(
+      config.getInt("connection-pool.max-pool-size"))
+
+    val timeout = config.getDuration("connection-pool.timeout").toMillis
+    dataSource.setConnectionTimeout(timeout)
+
+    dataSource.setDriverClassName(config.getString("driver"))
+    dataSource.setJdbcUrl(config.getString("url"))
+    dataSource.setUsername(config.getString("user"))
+    dataSource.setPassword(config.getString("password"))
+
+    dataSource
   }
 
   /**

--- a/docs-source/docs/modules/microservices-tutorial/examples/02-shopping-cart-service-java/src/main/java/shopping/cart/repository/SpringConfig.java
+++ b/docs-source/docs/modules/microservices-tutorial/examples/02-shopping-cart-service-java/src/main/java/shopping/cart/repository/SpringConfig.java
@@ -70,24 +70,27 @@ public class SpringConfig {
 
     HikariDataSource dataSource = new HikariDataSource();
 
+    Config jdbcConfig = jdbcConfig();
+
     // pool configuration
     dataSource.setPoolName("read-side-connection-pool");
-    dataSource.setMaximumPoolSize(
-        config.getInt("jdbc-connection-settings.connection-pool.max-pool-size"));
+    dataSource.setMaximumPoolSize(jdbcConfig.getInt("connection-pool.max-pool-size"));
 
-    long timeout =
-        config.getDuration(
-            "jdbc-connection-settings.connection-pool.timeout", TimeUnit.MILLISECONDS);
+    long timeout = jdbcConfig.getDuration("connection-pool.timeout", TimeUnit.MILLISECONDS);
     dataSource.setConnectionTimeout(timeout);
 
     // database configuration
-    dataSource.setDriverClassName(config.getString("jdbc-connection-settings.driver"));
-    dataSource.setJdbcUrl(config.getString("jdbc-connection-settings.url"));
-    dataSource.setUsername(config.getString("jdbc-connection-settings.user"));
-    dataSource.setPassword(config.getString("jdbc-connection-settings.password"));
+    dataSource.setDriverClassName(jdbcConfig.getString("driver"));
+    dataSource.setJdbcUrl(jdbcConfig.getString("url"));
+    dataSource.setUsername(jdbcConfig.getString("user"));
+    dataSource.setPassword(jdbcConfig.getString("password"));
     dataSource.setAutoCommit(false);
 
     return dataSource;
+  }
+
+  private Config jdbcConfig() {
+    return config.getConfig("jdbc-connection-settings");
   }
 
   /**
@@ -98,8 +101,7 @@ public class SpringConfig {
   Properties additionalProperties() {
     Properties properties = new Properties();
 
-    Config additionalProperties =
-        this.config.getConfig("jdbc-connection-settings.additional-properties");
+    Config additionalProperties = jdbcConfig().getConfig("additional-properties");
     Set<Map.Entry<String, ConfigValue>> entries = additionalProperties.entrySet();
 
     for (Map.Entry<String, ConfigValue> entry : entries) {

--- a/docs-source/docs/modules/microservices-tutorial/examples/02-shopping-cart-service-scala/src/main/scala/shopping/cart/repository/ScalikeJdbcSetup.scala
+++ b/docs-source/docs/modules/microservices-tutorial/examples/02-shopping-cart-service-scala/src/main/scala/shopping/cart/repository/ScalikeJdbcSetup.scala
@@ -20,7 +20,7 @@ object ScalikeJdbcSetup {
    * The connection pool will be closed when the actor system terminates.
    */
   def init(system: ActorSystem[_]): Unit = {
-    fromConfig(system.settings.config)
+    initFromConfig(system.settings.config)
     system.whenTerminated.map { _ =>
       ConnectionPool.closeAll()
     }(scala.concurrent.ExecutionContext.Implicits.global)
@@ -31,34 +31,36 @@ object ScalikeJdbcSetup {
    * Builds a Hikari DataSource with values from jdbc-connection-settings.
    * The DataSource is then configured as the 'default' connection pool for ScalikeJDBC.
    */
-  def fromConfig(config: Config): Unit = {
+  private def initFromConfig(config: Config): Unit = {
 
     val dbs = new DBsFromConfig(config)
     dbs.loadGlobalSettings()
 
-    val dataSource = new HikariDataSource()
-
-    dataSource.setPoolName("read-side-connection-pool")
-    dataSource.setMaximumPoolSize(
-      config.getInt("jdbc-connection-settings.connection-pool.max-pool-size"))
-
-    val timeout =
-      config
-        .getDuration("jdbc-connection-settings.connection-pool.timeout")
-        .toMillis
-    dataSource.setConnectionTimeout(timeout)
-
-    dataSource.setDriverClassName(
-      config.getString("jdbc-connection-settings.driver"))
-    dataSource.setJdbcUrl(config.getString("jdbc-connection-settings.url"))
-    dataSource.setUsername(config.getString("jdbc-connection-settings.user"))
-    dataSource.setPassword(
-      config.getString("jdbc-connection-settings.password"))
+    val dataSource = buildDataSource(
+      config.getConfig("jdbc-connection-settings"))
 
     ConnectionPool.singleton(
       new DataSourceConnectionPool(
         dataSource = dataSource,
         closer = HikariCloser(dataSource)))
+  }
+
+  private def buildDataSource(config: Config): HikariDataSource = {
+    val dataSource = new HikariDataSource()
+
+    dataSource.setPoolName("read-side-connection-pool")
+    dataSource.setMaximumPoolSize(
+      config.getInt("connection-pool.max-pool-size"))
+
+    val timeout = config.getDuration("connection-pool.timeout").toMillis
+    dataSource.setConnectionTimeout(timeout)
+
+    dataSource.setDriverClassName(config.getString("driver"))
+    dataSource.setJdbcUrl(config.getString("url"))
+    dataSource.setUsername(config.getString("user"))
+    dataSource.setPassword(config.getString("password"))
+
+    dataSource
   }
 
   /**

--- a/docs-source/docs/modules/microservices-tutorial/examples/02-shopping-cart-service-scala/src/test/scala/shopping/cart/IntegrationSpec.scala
+++ b/docs-source/docs/modules/microservices-tutorial/examples/02-shopping-cart-service-scala/src/test/scala/shopping/cart/IntegrationSpec.scala
@@ -21,7 +21,6 @@ import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.time.Span
 import org.scalatest.wordspec.AnyWordSpec
-import scalikejdbc.ConnectionPool
 import shopping.cart.repository.ScalikeJdbcSetup
 
 object IntegrationSpec {
@@ -106,7 +105,7 @@ class IntegrationSpec
 
   override protected def beforeAll(): Unit = {
     super.beforeAll()
-    ScalikeJdbcSetup.fromConfig(IntegrationSpec.sharedConfig)
+    ScalikeJdbcSetup.init(testNode1.system)
     CreateTableTestUtils.dropAndRecreateTables(testNode1.system)
     // avoid concurrent creation of tables
     val timeout = 10.seconds
@@ -119,8 +118,9 @@ class IntegrationSpec
     super.afterAll()
     testNode3.testKit.shutdownTestKit()
     testNode2.testKit.shutdownTestKit()
+    // testNode1 must be the last to shutdown
+    // because responsible to close ScalikeJdbc connections
     testNode1.testKit.shutdownTestKit()
-    ConnectionPool.closeAll()
   }
 
   "Shopping Cart service" should {

--- a/docs-source/docs/modules/microservices-tutorial/examples/03-shopping-cart-service-java/src/main/java/shopping/cart/repository/SpringConfig.java
+++ b/docs-source/docs/modules/microservices-tutorial/examples/03-shopping-cart-service-java/src/main/java/shopping/cart/repository/SpringConfig.java
@@ -70,24 +70,27 @@ public class SpringConfig {
 
     HikariDataSource dataSource = new HikariDataSource();
 
+    Config jdbcConfig = jdbcConfig();
+
     // pool configuration
     dataSource.setPoolName("read-side-connection-pool");
-    dataSource.setMaximumPoolSize(
-        config.getInt("jdbc-connection-settings.connection-pool.max-pool-size"));
+    dataSource.setMaximumPoolSize(jdbcConfig.getInt("connection-pool.max-pool-size"));
 
-    long timeout =
-        config.getDuration(
-            "jdbc-connection-settings.connection-pool.timeout", TimeUnit.MILLISECONDS);
+    long timeout = jdbcConfig.getDuration("connection-pool.timeout", TimeUnit.MILLISECONDS);
     dataSource.setConnectionTimeout(timeout);
 
     // database configuration
-    dataSource.setDriverClassName(config.getString("jdbc-connection-settings.driver"));
-    dataSource.setJdbcUrl(config.getString("jdbc-connection-settings.url"));
-    dataSource.setUsername(config.getString("jdbc-connection-settings.user"));
-    dataSource.setPassword(config.getString("jdbc-connection-settings.password"));
+    dataSource.setDriverClassName(jdbcConfig.getString("driver"));
+    dataSource.setJdbcUrl(jdbcConfig.getString("url"));
+    dataSource.setUsername(jdbcConfig.getString("user"));
+    dataSource.setPassword(jdbcConfig.getString("password"));
     dataSource.setAutoCommit(false);
 
     return dataSource;
+  }
+
+  private Config jdbcConfig() {
+    return config.getConfig("jdbc-connection-settings");
   }
 
   /**
@@ -98,8 +101,7 @@ public class SpringConfig {
   Properties additionalProperties() {
     Properties properties = new Properties();
 
-    Config additionalProperties =
-        this.config.getConfig("jdbc-connection-settings.additional-properties");
+    Config additionalProperties = jdbcConfig().getConfig("additional-properties");
     Set<Map.Entry<String, ConfigValue>> entries = additionalProperties.entrySet();
 
     for (Map.Entry<String, ConfigValue> entry : entries) {

--- a/docs-source/docs/modules/microservices-tutorial/examples/03-shopping-cart-service-scala/src/main/scala/shopping/cart/repository/ScalikeJdbcSetup.scala
+++ b/docs-source/docs/modules/microservices-tutorial/examples/03-shopping-cart-service-scala/src/main/scala/shopping/cart/repository/ScalikeJdbcSetup.scala
@@ -20,7 +20,7 @@ object ScalikeJdbcSetup {
    * The connection pool will be closed when the actor system terminates.
    */
   def init(system: ActorSystem[_]): Unit = {
-    fromConfig(system.settings.config)
+    initFromConfig(system.settings.config)
     system.whenTerminated.map { _ =>
       ConnectionPool.closeAll()
     }(scala.concurrent.ExecutionContext.Implicits.global)
@@ -31,34 +31,36 @@ object ScalikeJdbcSetup {
    * Builds a Hikari DataSource with values from jdbc-connection-settings.
    * The DataSource is then configured as the 'default' connection pool for ScalikeJDBC.
    */
-  def fromConfig(config: Config): Unit = {
+  private def initFromConfig(config: Config): Unit = {
 
     val dbs = new DBsFromConfig(config)
     dbs.loadGlobalSettings()
 
-    val dataSource = new HikariDataSource()
-
-    dataSource.setPoolName("read-side-connection-pool")
-    dataSource.setMaximumPoolSize(
-      config.getInt("jdbc-connection-settings.connection-pool.max-pool-size"))
-
-    val timeout =
-      config
-        .getDuration("jdbc-connection-settings.connection-pool.timeout")
-        .toMillis
-    dataSource.setConnectionTimeout(timeout)
-
-    dataSource.setDriverClassName(
-      config.getString("jdbc-connection-settings.driver"))
-    dataSource.setJdbcUrl(config.getString("jdbc-connection-settings.url"))
-    dataSource.setUsername(config.getString("jdbc-connection-settings.user"))
-    dataSource.setPassword(
-      config.getString("jdbc-connection-settings.password"))
+    val dataSource = buildDataSource(
+      config.getConfig("jdbc-connection-settings"))
 
     ConnectionPool.singleton(
       new DataSourceConnectionPool(
         dataSource = dataSource,
         closer = HikariCloser(dataSource)))
+  }
+
+  private def buildDataSource(config: Config): HikariDataSource = {
+    val dataSource = new HikariDataSource()
+
+    dataSource.setPoolName("read-side-connection-pool")
+    dataSource.setMaximumPoolSize(
+      config.getInt("connection-pool.max-pool-size"))
+
+    val timeout = config.getDuration("connection-pool.timeout").toMillis
+    dataSource.setConnectionTimeout(timeout)
+
+    dataSource.setDriverClassName(config.getString("driver"))
+    dataSource.setJdbcUrl(config.getString("url"))
+    dataSource.setUsername(config.getString("user"))
+    dataSource.setPassword(config.getString("password"))
+
+    dataSource
   }
 
   /**

--- a/docs-source/docs/modules/microservices-tutorial/examples/03-shopping-cart-service-scala/src/test/scala/shopping/cart/IntegrationSpec.scala
+++ b/docs-source/docs/modules/microservices-tutorial/examples/03-shopping-cart-service-scala/src/test/scala/shopping/cart/IntegrationSpec.scala
@@ -21,7 +21,6 @@ import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.time.Span
 import org.scalatest.wordspec.AnyWordSpec
-import scalikejdbc.ConnectionPool
 import shopping.cart.repository.ScalikeJdbcSetup
 
 object IntegrationSpec {
@@ -106,7 +105,7 @@ class IntegrationSpec
 
   override protected def beforeAll(): Unit = {
     super.beforeAll()
-    ScalikeJdbcSetup.fromConfig(IntegrationSpec.sharedConfig)
+    ScalikeJdbcSetup.init(testNode1.system)
     CreateTableTestUtils.dropAndRecreateTables(testNode1.system)
     // avoid concurrent creation of tables
     val timeout = 10.seconds
@@ -119,8 +118,9 @@ class IntegrationSpec
     super.afterAll()
     testNode3.testKit.shutdownTestKit()
     testNode2.testKit.shutdownTestKit()
+    // testNode1 must be the last to shutdown
+    // because responsible to close ScalikeJdbc connections
     testNode1.testKit.shutdownTestKit()
-    ConnectionPool.closeAll()
   }
 
   "Shopping Cart service" should {

--- a/docs-source/docs/modules/microservices-tutorial/examples/04-shopping-cart-service-java/src/main/java/shopping/cart/repository/SpringConfig.java
+++ b/docs-source/docs/modules/microservices-tutorial/examples/04-shopping-cart-service-java/src/main/java/shopping/cart/repository/SpringConfig.java
@@ -70,24 +70,27 @@ public class SpringConfig {
 
     HikariDataSource dataSource = new HikariDataSource();
 
+    Config jdbcConfig = jdbcConfig();
+
     // pool configuration
     dataSource.setPoolName("read-side-connection-pool");
-    dataSource.setMaximumPoolSize(
-        config.getInt("jdbc-connection-settings.connection-pool.max-pool-size"));
+    dataSource.setMaximumPoolSize(jdbcConfig.getInt("connection-pool.max-pool-size"));
 
-    long timeout =
-        config.getDuration(
-            "jdbc-connection-settings.connection-pool.timeout", TimeUnit.MILLISECONDS);
+    long timeout = jdbcConfig.getDuration("connection-pool.timeout", TimeUnit.MILLISECONDS);
     dataSource.setConnectionTimeout(timeout);
 
     // database configuration
-    dataSource.setDriverClassName(config.getString("jdbc-connection-settings.driver"));
-    dataSource.setJdbcUrl(config.getString("jdbc-connection-settings.url"));
-    dataSource.setUsername(config.getString("jdbc-connection-settings.user"));
-    dataSource.setPassword(config.getString("jdbc-connection-settings.password"));
+    dataSource.setDriverClassName(jdbcConfig.getString("driver"));
+    dataSource.setJdbcUrl(jdbcConfig.getString("url"));
+    dataSource.setUsername(jdbcConfig.getString("user"));
+    dataSource.setPassword(jdbcConfig.getString("password"));
     dataSource.setAutoCommit(false);
 
     return dataSource;
+  }
+
+  private Config jdbcConfig() {
+    return config.getConfig("jdbc-connection-settings");
   }
 
   /**
@@ -98,8 +101,7 @@ public class SpringConfig {
   Properties additionalProperties() {
     Properties properties = new Properties();
 
-    Config additionalProperties =
-        this.config.getConfig("jdbc-connection-settings.additional-properties");
+    Config additionalProperties = jdbcConfig().getConfig("additional-properties");
     Set<Map.Entry<String, ConfigValue>> entries = additionalProperties.entrySet();
 
     for (Map.Entry<String, ConfigValue> entry : entries) {

--- a/docs-source/docs/modules/microservices-tutorial/examples/04-shopping-cart-service-scala/src/main/scala/shopping/cart/repository/ScalikeJdbcSetup.scala
+++ b/docs-source/docs/modules/microservices-tutorial/examples/04-shopping-cart-service-scala/src/main/scala/shopping/cart/repository/ScalikeJdbcSetup.scala
@@ -20,7 +20,7 @@ object ScalikeJdbcSetup {
    * The connection pool will be closed when the actor system terminates.
    */
   def init(system: ActorSystem[_]): Unit = {
-    fromConfig(system.settings.config)
+    initFromConfig(system.settings.config)
     system.whenTerminated.map { _ =>
       ConnectionPool.closeAll()
     }(scala.concurrent.ExecutionContext.Implicits.global)
@@ -31,34 +31,36 @@ object ScalikeJdbcSetup {
    * Builds a Hikari DataSource with values from jdbc-connection-settings.
    * The DataSource is then configured as the 'default' connection pool for ScalikeJDBC.
    */
-  def fromConfig(config: Config): Unit = {
+  private def initFromConfig(config: Config): Unit = {
 
     val dbs = new DBsFromConfig(config)
     dbs.loadGlobalSettings()
 
-    val dataSource = new HikariDataSource()
-
-    dataSource.setPoolName("read-side-connection-pool")
-    dataSource.setMaximumPoolSize(
-      config.getInt("jdbc-connection-settings.connection-pool.max-pool-size"))
-
-    val timeout =
-      config
-        .getDuration("jdbc-connection-settings.connection-pool.timeout")
-        .toMillis
-    dataSource.setConnectionTimeout(timeout)
-
-    dataSource.setDriverClassName(
-      config.getString("jdbc-connection-settings.driver"))
-    dataSource.setJdbcUrl(config.getString("jdbc-connection-settings.url"))
-    dataSource.setUsername(config.getString("jdbc-connection-settings.user"))
-    dataSource.setPassword(
-      config.getString("jdbc-connection-settings.password"))
+    val dataSource = buildDataSource(
+      config.getConfig("jdbc-connection-settings"))
 
     ConnectionPool.singleton(
       new DataSourceConnectionPool(
         dataSource = dataSource,
         closer = HikariCloser(dataSource)))
+  }
+
+  private def buildDataSource(config: Config): HikariDataSource = {
+    val dataSource = new HikariDataSource()
+
+    dataSource.setPoolName("read-side-connection-pool")
+    dataSource.setMaximumPoolSize(
+      config.getInt("connection-pool.max-pool-size"))
+
+    val timeout = config.getDuration("connection-pool.timeout").toMillis
+    dataSource.setConnectionTimeout(timeout)
+
+    dataSource.setDriverClassName(config.getString("driver"))
+    dataSource.setJdbcUrl(config.getString("url"))
+    dataSource.setUsername(config.getString("user"))
+    dataSource.setPassword(config.getString("password"))
+
+    dataSource
   }
 
   /**

--- a/docs-source/docs/modules/microservices-tutorial/examples/04-shopping-cart-service-scala/src/test/scala/shopping/cart/IntegrationSpec.scala
+++ b/docs-source/docs/modules/microservices-tutorial/examples/04-shopping-cart-service-scala/src/test/scala/shopping/cart/IntegrationSpec.scala
@@ -21,7 +21,6 @@ import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.time.Span
 import org.scalatest.wordspec.AnyWordSpec
-import scalikejdbc.ConnectionPool
 import shopping.cart.repository.ScalikeJdbcSetup
 
 object IntegrationSpec {
@@ -106,7 +105,7 @@ class IntegrationSpec
 
   override protected def beforeAll(): Unit = {
     super.beforeAll()
-    ScalikeJdbcSetup.fromConfig(IntegrationSpec.sharedConfig)
+    ScalikeJdbcSetup.init(testNode1.system)
     CreateTableTestUtils.dropAndRecreateTables(testNode1.system)
     // avoid concurrent creation of tables
     val timeout = 10.seconds
@@ -119,8 +118,9 @@ class IntegrationSpec
     super.afterAll()
     testNode3.testKit.shutdownTestKit()
     testNode2.testKit.shutdownTestKit()
+    // testNode1 must be the last to shutdown
+    // because responsible to close ScalikeJdbc connections
     testNode1.testKit.shutdownTestKit()
-    ConnectionPool.closeAll()
   }
 
   "Shopping Cart service" should {

--- a/docs-source/docs/modules/microservices-tutorial/examples/05-shopping-cart-service-java/src/main/java/shopping/cart/repository/SpringConfig.java
+++ b/docs-source/docs/modules/microservices-tutorial/examples/05-shopping-cart-service-java/src/main/java/shopping/cart/repository/SpringConfig.java
@@ -70,24 +70,27 @@ public class SpringConfig {
 
     HikariDataSource dataSource = new HikariDataSource();
 
+    Config jdbcConfig = jdbcConfig();
+
     // pool configuration
     dataSource.setPoolName("read-side-connection-pool");
-    dataSource.setMaximumPoolSize(
-        config.getInt("jdbc-connection-settings.connection-pool.max-pool-size"));
+    dataSource.setMaximumPoolSize(jdbcConfig.getInt("connection-pool.max-pool-size"));
 
-    long timeout =
-        config.getDuration(
-            "jdbc-connection-settings.connection-pool.timeout", TimeUnit.MILLISECONDS);
+    long timeout = jdbcConfig.getDuration("connection-pool.timeout", TimeUnit.MILLISECONDS);
     dataSource.setConnectionTimeout(timeout);
 
     // database configuration
-    dataSource.setDriverClassName(config.getString("jdbc-connection-settings.driver"));
-    dataSource.setJdbcUrl(config.getString("jdbc-connection-settings.url"));
-    dataSource.setUsername(config.getString("jdbc-connection-settings.user"));
-    dataSource.setPassword(config.getString("jdbc-connection-settings.password"));
+    dataSource.setDriverClassName(jdbcConfig.getString("driver"));
+    dataSource.setJdbcUrl(jdbcConfig.getString("url"));
+    dataSource.setUsername(jdbcConfig.getString("user"));
+    dataSource.setPassword(jdbcConfig.getString("password"));
     dataSource.setAutoCommit(false);
 
     return dataSource;
+  }
+
+  private Config jdbcConfig() {
+    return config.getConfig("jdbc-connection-settings");
   }
 
   /**
@@ -98,8 +101,7 @@ public class SpringConfig {
   Properties additionalProperties() {
     Properties properties = new Properties();
 
-    Config additionalProperties =
-        this.config.getConfig("jdbc-connection-settings.additional-properties");
+    Config additionalProperties = jdbcConfig().getConfig("additional-properties");
     Set<Map.Entry<String, ConfigValue>> entries = additionalProperties.entrySet();
 
     for (Map.Entry<String, ConfigValue> entry : entries) {

--- a/docs-source/docs/modules/microservices-tutorial/examples/05-shopping-cart-service-scala/src/main/scala/shopping/cart/repository/ScalikeJdbcSetup.scala
+++ b/docs-source/docs/modules/microservices-tutorial/examples/05-shopping-cart-service-scala/src/main/scala/shopping/cart/repository/ScalikeJdbcSetup.scala
@@ -20,7 +20,7 @@ object ScalikeJdbcSetup {
    * The connection pool will be closed when the actor system terminates.
    */
   def init(system: ActorSystem[_]): Unit = {
-    fromConfig(system.settings.config)
+    initFromConfig(system.settings.config)
     system.whenTerminated.map { _ =>
       ConnectionPool.closeAll()
     }(scala.concurrent.ExecutionContext.Implicits.global)
@@ -31,34 +31,36 @@ object ScalikeJdbcSetup {
    * Builds a Hikari DataSource with values from jdbc-connection-settings.
    * The DataSource is then configured as the 'default' connection pool for ScalikeJDBC.
    */
-  def fromConfig(config: Config): Unit = {
+  private def initFromConfig(config: Config): Unit = {
 
     val dbs = new DBsFromConfig(config)
     dbs.loadGlobalSettings()
 
-    val dataSource = new HikariDataSource()
-
-    dataSource.setPoolName("read-side-connection-pool")
-    dataSource.setMaximumPoolSize(
-      config.getInt("jdbc-connection-settings.connection-pool.max-pool-size"))
-
-    val timeout =
-      config
-        .getDuration("jdbc-connection-settings.connection-pool.timeout")
-        .toMillis
-    dataSource.setConnectionTimeout(timeout)
-
-    dataSource.setDriverClassName(
-      config.getString("jdbc-connection-settings.driver"))
-    dataSource.setJdbcUrl(config.getString("jdbc-connection-settings.url"))
-    dataSource.setUsername(config.getString("jdbc-connection-settings.user"))
-    dataSource.setPassword(
-      config.getString("jdbc-connection-settings.password"))
+    val dataSource = buildDataSource(
+      config.getConfig("jdbc-connection-settings"))
 
     ConnectionPool.singleton(
       new DataSourceConnectionPool(
         dataSource = dataSource,
         closer = HikariCloser(dataSource)))
+  }
+
+  private def buildDataSource(config: Config): HikariDataSource = {
+    val dataSource = new HikariDataSource()
+
+    dataSource.setPoolName("read-side-connection-pool")
+    dataSource.setMaximumPoolSize(
+      config.getInt("connection-pool.max-pool-size"))
+
+    val timeout = config.getDuration("connection-pool.timeout").toMillis
+    dataSource.setConnectionTimeout(timeout)
+
+    dataSource.setDriverClassName(config.getString("driver"))
+    dataSource.setJdbcUrl(config.getString("url"))
+    dataSource.setUsername(config.getString("user"))
+    dataSource.setPassword(config.getString("password"))
+
+    dataSource
   }
 
   /**

--- a/docs-source/docs/modules/microservices-tutorial/examples/05-shopping-cart-service-scala/src/test/scala/shopping/cart/IntegrationSpec.scala
+++ b/docs-source/docs/modules/microservices-tutorial/examples/05-shopping-cart-service-scala/src/test/scala/shopping/cart/IntegrationSpec.scala
@@ -31,7 +31,6 @@ import org.scalatest.matchers.should.Matchers
 import org.scalatest.time.Span
 import org.scalatest.wordspec.AnyWordSpec
 import org.slf4j.LoggerFactory
-import scalikejdbc.ConnectionPool
 import shopping.cart.repository.ScalikeJdbcSetup
 
 object IntegrationSpec {
@@ -122,7 +121,7 @@ class IntegrationSpec
 
   override protected def beforeAll(): Unit = {
     super.beforeAll()
-    ScalikeJdbcSetup.fromConfig(IntegrationSpec.sharedConfig)
+    ScalikeJdbcSetup.init(testNode1.system)
     CreateTableTestUtils.dropAndRecreateTables(testNode1.system)
     // avoid concurrent creation of tables
     val timeout = 10.seconds
@@ -175,8 +174,9 @@ class IntegrationSpec
     super.afterAll()
     testNode3.testKit.shutdownTestKit()
     testNode2.testKit.shutdownTestKit()
+    // testNode1 must be the last to shutdown
+    // because responsible to close ScalikeJdbc connections
     testNode1.testKit.shutdownTestKit()
-    ConnectionPool.closeAll()
   }
 
   "Shopping Cart service" should {

--- a/docs-source/docs/modules/microservices-tutorial/examples/shopping-cart-service-java/src/main/java/shopping/cart/repository/SpringConfig.java
+++ b/docs-source/docs/modules/microservices-tutorial/examples/shopping-cart-service-java/src/main/java/shopping/cart/repository/SpringConfig.java
@@ -70,24 +70,27 @@ public class SpringConfig {
 
     HikariDataSource dataSource = new HikariDataSource();
 
+    Config jdbcConfig = jdbcConfig();
+
     // pool configuration
     dataSource.setPoolName("read-side-connection-pool");
-    dataSource.setMaximumPoolSize(
-        config.getInt("jdbc-connection-settings.connection-pool.max-pool-size"));
+    dataSource.setMaximumPoolSize(jdbcConfig.getInt("connection-pool.max-pool-size"));
 
-    long timeout =
-        config.getDuration(
-            "jdbc-connection-settings.connection-pool.timeout", TimeUnit.MILLISECONDS);
+    long timeout = jdbcConfig.getDuration("connection-pool.timeout", TimeUnit.MILLISECONDS);
     dataSource.setConnectionTimeout(timeout);
 
     // database configuration
-    dataSource.setDriverClassName(config.getString("jdbc-connection-settings.driver"));
-    dataSource.setJdbcUrl(config.getString("jdbc-connection-settings.url"));
-    dataSource.setUsername(config.getString("jdbc-connection-settings.user"));
-    dataSource.setPassword(config.getString("jdbc-connection-settings.password"));
+    dataSource.setDriverClassName(jdbcConfig.getString("driver"));
+    dataSource.setJdbcUrl(jdbcConfig.getString("url"));
+    dataSource.setUsername(jdbcConfig.getString("user"));
+    dataSource.setPassword(jdbcConfig.getString("password"));
     dataSource.setAutoCommit(false);
 
     return dataSource;
+  }
+
+  private Config jdbcConfig() {
+    return config.getConfig("jdbc-connection-settings");
   }
 
   /**
@@ -98,8 +101,7 @@ public class SpringConfig {
   Properties additionalProperties() {
     Properties properties = new Properties();
 
-    Config additionalProperties =
-        this.config.getConfig("jdbc-connection-settings.additional-properties");
+    Config additionalProperties = jdbcConfig().getConfig("additional-properties");
     Set<Map.Entry<String, ConfigValue>> entries = additionalProperties.entrySet();
 
     for (Map.Entry<String, ConfigValue> entry : entries) {

--- a/docs-source/docs/modules/microservices-tutorial/examples/shopping-cart-service-scala/src/main/scala/shopping/cart/repository/ScalikeJdbcSetup.scala
+++ b/docs-source/docs/modules/microservices-tutorial/examples/shopping-cart-service-scala/src/main/scala/shopping/cart/repository/ScalikeJdbcSetup.scala
@@ -20,7 +20,7 @@ object ScalikeJdbcSetup {
    * The connection pool will be closed when the actor system terminates.
    */
   def init(system: ActorSystem[_]): Unit = {
-    fromConfig(system.settings.config)
+    initFromConfig(system.settings.config)
     system.whenTerminated.map { _ =>
       ConnectionPool.closeAll()
     }(scala.concurrent.ExecutionContext.Implicits.global)
@@ -31,34 +31,36 @@ object ScalikeJdbcSetup {
    * Builds a Hikari DataSource with values from jdbc-connection-settings.
    * The DataSource is then configured as the 'default' connection pool for ScalikeJDBC.
    */
-  def fromConfig(config: Config): Unit = {
+  private def initFromConfig(config: Config): Unit = {
 
     val dbs = new DBsFromConfig(config)
     dbs.loadGlobalSettings()
 
-    val dataSource = new HikariDataSource()
-
-    dataSource.setPoolName("read-side-connection-pool")
-    dataSource.setMaximumPoolSize(
-      config.getInt("jdbc-connection-settings.connection-pool.max-pool-size"))
-
-    val timeout =
-      config
-        .getDuration("jdbc-connection-settings.connection-pool.timeout")
-        .toMillis
-    dataSource.setConnectionTimeout(timeout)
-
-    dataSource.setDriverClassName(
-      config.getString("jdbc-connection-settings.driver"))
-    dataSource.setJdbcUrl(config.getString("jdbc-connection-settings.url"))
-    dataSource.setUsername(config.getString("jdbc-connection-settings.user"))
-    dataSource.setPassword(
-      config.getString("jdbc-connection-settings.password"))
+    val dataSource = buildDataSource(
+      config.getConfig("jdbc-connection-settings"))
 
     ConnectionPool.singleton(
       new DataSourceConnectionPool(
         dataSource = dataSource,
         closer = HikariCloser(dataSource)))
+  }
+
+  private def buildDataSource(config: Config): HikariDataSource = {
+    val dataSource = new HikariDataSource()
+
+    dataSource.setPoolName("read-side-connection-pool")
+    dataSource.setMaximumPoolSize(
+      config.getInt("connection-pool.max-pool-size"))
+
+    val timeout = config.getDuration("connection-pool.timeout").toMillis
+    dataSource.setConnectionTimeout(timeout)
+
+    dataSource.setDriverClassName(config.getString("driver"))
+    dataSource.setJdbcUrl(config.getString("url"))
+    dataSource.setUsername(config.getString("user"))
+    dataSource.setPassword(config.getString("password"))
+
+    dataSource
   }
 
   /**

--- a/docs-source/docs/modules/microservices-tutorial/examples/shopping-cart-service-scala/src/test/scala/shopping/cart/IntegrationSpec.scala
+++ b/docs-source/docs/modules/microservices-tutorial/examples/shopping-cart-service-scala/src/test/scala/shopping/cart/IntegrationSpec.scala
@@ -32,7 +32,6 @@ import org.scalatest.matchers.should.Matchers
 import org.scalatest.time.Span
 import org.scalatest.wordspec.AnyWordSpec
 import org.slf4j.LoggerFactory
-import scalikejdbc.ConnectionPool
 import shopping.cart.repository.ScalikeJdbcSetup
 import shopping.order.proto.OrderRequest
 import shopping.order.proto.OrderResponse
@@ -142,7 +141,7 @@ class IntegrationSpec
 
   override protected def beforeAll(): Unit = {
     super.beforeAll()
-    ScalikeJdbcSetup.fromConfig(IntegrationSpec.sharedConfig)
+    ScalikeJdbcSetup.init(testNode1.system)
     CreateTableTestUtils.dropAndRecreateTables(testNode1.system)
     // avoid concurrent creation of tables
     val timeout = 10.seconds
@@ -195,8 +194,9 @@ class IntegrationSpec
     super.afterAll()
     testNode3.testKit.shutdownTestKit()
     testNode2.testKit.shutdownTestKit()
+    // testNode1 must be the last to shutdown
+    // because responsible to close ScalikeJdbc connections
     testNode1.testKit.shutdownTestKit()
-    ConnectionPool.closeAll()
   }
 
   "Shopping Cart service" should {


### PR DESCRIPTION
This is a gardening task I had on my list for a while. 

* moves the jdbc-settings to separated method as suggested here: https://github.com/akka/akka-platform-guide/pull/493#discussion_r561664055
* make ScalikeJdbcSetup.fromConfig private, the reason we had it open is that we needed it for one tests, but it's not needed so better to remove it to have tests aligned 