### PR TITLE
Reduce shopping-order-service k8s requirements

### DIFF
--- a/docs-source/docs/modules/microservices-tutorial/examples/00-shopping-order-service-java/kubernetes/shopping-order-service-cr.yml
+++ b/docs-source/docs/modules/microservices-tutorial/examples/00-shopping-order-service-java/kubernetes/shopping-order-service-cr.yml
@@ -14,7 +14,7 @@ spec:
   javaOptions: "-Xlog:gc -XX:InitialRAMPercentage=75 -XX:MaxRAMPercentage=75"
   resources:
     limits:
-      memory: "250M"
+      memory: 250Mi
     requests:
-      memory: "250M"
-      cpu: "0.2"
+      memory: 250Mi
+      cpu: 200m

--- a/docs-source/docs/modules/microservices-tutorial/examples/00-shopping-order-service-java/kubernetes/shopping-order-service-cr.yml
+++ b/docs-source/docs/modules/microservices-tutorial/examples/00-shopping-order-service-java/kubernetes/shopping-order-service-cr.yml
@@ -14,7 +14,7 @@ spec:
   javaOptions: "-Xlog:gc -XX:InitialRAMPercentage=75 -XX:MaxRAMPercentage=75"
   resources:
     limits:
-      memory: "2Gi"
+      memory: "250M"
     requests:
-      memory: "2Gi"
-      cpu: "1"
+      memory: "250M"
+      cpu: "0.2"

--- a/docs-source/docs/modules/microservices-tutorial/examples/00-shopping-order-service-scala/kubernetes/shopping-order-service-cr.yml
+++ b/docs-source/docs/modules/microservices-tutorial/examples/00-shopping-order-service-scala/kubernetes/shopping-order-service-cr.yml
@@ -14,7 +14,7 @@ spec:
   javaOptions: "-Xlog:gc -XX:InitialRAMPercentage=75 -XX:MaxRAMPercentage=75"
   resources:
     limits:
-      memory: "250M"
+      memory: 250Mi
     requests:
-      memory: "250M"
-      cpu: "0.2"
+      memory: 250Mi
+      cpu: 200m

--- a/docs-source/docs/modules/microservices-tutorial/examples/00-shopping-order-service-scala/kubernetes/shopping-order-service-cr.yml
+++ b/docs-source/docs/modules/microservices-tutorial/examples/00-shopping-order-service-scala/kubernetes/shopping-order-service-cr.yml
@@ -14,7 +14,7 @@ spec:
   javaOptions: "-Xlog:gc -XX:InitialRAMPercentage=75 -XX:MaxRAMPercentage=75"
   resources:
     limits:
-      memory: "2Gi"
+      memory: "250M"
     requests:
-      memory: "2Gi"
-      cpu: "1"
+      memory: "250M"
+      cpu: "0.2"

--- a/docs-source/docs/modules/microservices-tutorial/examples/shopping-order-service-java/kubernetes/shopping-order-service-cr.yml
+++ b/docs-source/docs/modules/microservices-tutorial/examples/shopping-order-service-java/kubernetes/shopping-order-service-cr.yml
@@ -14,7 +14,7 @@ spec:
   javaOptions: "-Xlog:gc -XX:InitialRAMPercentage=75 -XX:MaxRAMPercentage=75"
   resources:
     limits:
-      memory: "250M"
+      memory: 250Mi
     requests:
-      memory: "250M"
-      cpu: "0.2"
+      memory: 250Mi
+      cpu: 200m

--- a/docs-source/docs/modules/microservices-tutorial/examples/shopping-order-service-java/kubernetes/shopping-order-service-cr.yml
+++ b/docs-source/docs/modules/microservices-tutorial/examples/shopping-order-service-java/kubernetes/shopping-order-service-cr.yml
@@ -14,7 +14,7 @@ spec:
   javaOptions: "-Xlog:gc -XX:InitialRAMPercentage=75 -XX:MaxRAMPercentage=75"
   resources:
     limits:
-      memory: "2Gi"
+      memory: "250M"
     requests:
-      memory: "2Gi"
-      cpu: "1"
+      memory: "250M"
+      cpu: "0.2"

--- a/docs-source/docs/modules/microservices-tutorial/examples/shopping-order-service-scala/kubernetes/shopping-order-service-cr.yml
+++ b/docs-source/docs/modules/microservices-tutorial/examples/shopping-order-service-scala/kubernetes/shopping-order-service-cr.yml
@@ -14,7 +14,7 @@ spec:
   javaOptions: "-Xlog:gc -XX:InitialRAMPercentage=75 -XX:MaxRAMPercentage=75"
   resources:
     limits:
-      memory: "250M"
+      memory: 250Mi
     requests:
-      memory: "250M"
-      cpu: "0.2"
+      memory: 250Mi
+      cpu: 200m

--- a/docs-source/docs/modules/microservices-tutorial/examples/shopping-order-service-scala/kubernetes/shopping-order-service-cr.yml
+++ b/docs-source/docs/modules/microservices-tutorial/examples/shopping-order-service-scala/kubernetes/shopping-order-service-cr.yml
@@ -14,7 +14,7 @@ spec:
   javaOptions: "-Xlog:gc -XX:InitialRAMPercentage=75 -XX:MaxRAMPercentage=75"
   resources:
     limits:
-      memory: "2Gi"
+      memory: "250M"
     requests:
-      memory: "2Gi"
-      cpu: "1"
+      memory: "250M"
+      cpu: "0.2"

--- a/docs-source/docs/modules/microservices-tutorial/examples/shopping-order-service-scala/src/main/scala/shopping/order/Main.scala
+++ b/docs-source/docs/modules/microservices-tutorial/examples/shopping-order-service-scala/src/main/scala/shopping/order/Main.scala
@@ -23,6 +23,8 @@ class Main(context: ActorContext[Nothing])
     extends AbstractBehavior[Nothing](context) {
   val system = context.system
 
+  println("v2")
+
   AkkaManagement(system).start()
   ClusterBootstrap(system).start()
 

--- a/docs-source/docs/modules/microservices-tutorial/examples/shopping-order-service-scala/src/main/scala/shopping/order/Main.scala
+++ b/docs-source/docs/modules/microservices-tutorial/examples/shopping-order-service-scala/src/main/scala/shopping/order/Main.scala
@@ -23,8 +23,6 @@ class Main(context: ActorContext[Nothing])
     extends AbstractBehavior[Nothing](context) {
   val system = context.system
 
-  println("v2")
-
   AkkaManagement(system).start()
   ClusterBootstrap(system).start()
 


### PR DESCRIPTION
Noticed that shopping-order-service requires too much CPU resources, so it's impossible to do a rolling-update of three replicas on a standard (3x m5.large) EKS cluster. The fourth pod can't start because of a lack of CPU resources.