### PR TITLE
Pin down transitive Akka modules

### DIFF
--- a/docs-source/docs/modules/microservices-tutorial/examples/05-shopping-cart-service-scala/build.sbt
+++ b/docs-source/docs/modules/microservices-tutorial/examples/05-shopping-cart-service-scala/build.sbt
@@ -42,25 +42,37 @@ ThisBuild / dynverSeparator := "-"
 
 libraryDependencies ++= Seq(
   // 1. Basic dependencies for a clustered application
+  "com.typesafe.akka" %% "akka-actor-typed" % AkkaVersion,
+  "com.typesafe.akka" %% "akka-actor" % AkkaVersion,
   "com.typesafe.akka" %% "akka-stream" % AkkaVersion,
   "com.typesafe.akka" %% "akka-cluster-typed" % AkkaVersion,
+  "com.typesafe.akka" %% "akka-cluster" % AkkaVersion,
+  "com.typesafe.akka" %% "akka-remote" % AkkaVersion,
+  "com.typesafe.akka" %% "akka-distributed-data" % AkkaVersion,
   "com.typesafe.akka" %% "akka-cluster-sharding-typed" % AkkaVersion,
+  "com.typesafe.akka" %% "akka-cluster-sharding" % AkkaVersion,
+  "com.typesafe.akka" %% "akka-cluster-tools" % AkkaVersion,
+  "com.typesafe.akka" %% "akka-protobuf-v3_2.13" % AkkaVersion,
   "com.typesafe.akka" %% "akka-actor-testkit-typed" % AkkaVersion % Test,
   "com.typesafe.akka" %% "akka-stream-testkit" % AkkaVersion % Test,
   // Akka Management powers Health Checks and Akka Cluster Bootstrapping
   "com.lightbend.akka.management" %% "akka-management" % AkkaManagementVersion,
   "com.typesafe.akka" %% "akka-http" % AkkaHttpVersion,
+  "com.typesafe.akka" %% "akka-http-core" % AkkaHttpVersion,
   "com.typesafe.akka" %% "akka-http-spray-json" % AkkaHttpVersion,
+  "com.typesafe.akka" %% "akka-parsing" % AkkaHttpVersion,
   "com.lightbend.akka.management" %% "akka-management-cluster-http" % AkkaManagementVersion,
   "com.lightbend.akka.management" %% "akka-management-cluster-bootstrap" % AkkaManagementVersion,
   "com.lightbend.akka.discovery" %% "akka-discovery-kubernetes-api" % AkkaManagementVersion,
   "com.typesafe.akka" %% "akka-discovery" % AkkaVersion,
+  "com.typesafe.akka" %% "akka-coordination" % AkkaVersion,
   // Common dependencies for logging and testing
   "com.typesafe.akka" %% "akka-slf4j" % AkkaVersion,
   "ch.qos.logback" % "logback-classic" % "1.2.3",
   "org.scalatest" %% "scalatest" % "3.1.2" % Test,
   // 2. Using gRPC and/or protobuf
   "com.typesafe.akka" %% "akka-http2-support" % AkkaHttpVersion,
+  "com.typesafe.akka" %% "akka-pki" % AkkaVersion,
   // 3. Using Akka Persistence
   "com.typesafe.akka" %% "akka-persistence-typed" % AkkaVersion,
   "com.typesafe.akka" %% "akka-serialization-jackson" % AkkaVersion,


### PR DESCRIPTION
References #460 

I've pinned down _all_ Akka modules even if transitive dependencies on `akka-remote` isn't very likely. I'm thinking better safe than sorry with a sample for beginners. Actually noted quite a few core modules where different other deps are trying to pull the version in one direction or the other (`akka-management`, `akka-projections` and `akka-persistence-jdbc`)

Would be good with someones eye on it before I port it to the maven/java sample and apply to all steps of the guide.
