### PR TITLE
avoid duplicate self-join in IntegrationTest, #586

### DIFF
--- a/docs-source/docs/modules/microservices-tutorial/examples/02-shopping-cart-service-java/src/test/resources/integration-test.conf
+++ b/docs-source/docs/modules/microservices-tutorial/examples/02-shopping-cart-service-java/src/test/resources/integration-test.conf
@@ -26,5 +26,12 @@ shopping-cart-service.grpc {
   interface = "localhost"
   // port = set by test per fixture
 }
+
 // akka.management.http.port = set by test per fixture
 // akka.discovery.config.services."shoppingcartservice".endpoints = set by test
+
+# don't self-join until all 3 have been started and probed sucessfully
+akka.management.cluster.bootstrap.contact-point-discovery {
+  required-contact-point-nr = 3
+  contact-with-all-contact-points = true
+}

--- a/docs-source/docs/modules/microservices-tutorial/examples/02-shopping-cart-service-scala/src/test/resources/integration-test.conf
+++ b/docs-source/docs/modules/microservices-tutorial/examples/02-shopping-cart-service-scala/src/test/resources/integration-test.conf
@@ -26,5 +26,12 @@ shopping-cart-service.grpc {
   interface = "localhost"
   // port = set by test per fixture
 }
+
 // akka.management.http.port = set by test per fixture
 // akka.discovery.config.services."shoppingcartservice".endpoints = set by test
+
+# don't self-join until all 3 have been started and probed sucessfully
+akka.management.cluster.bootstrap.contact-point-discovery {
+  required-contact-point-nr = 3
+  contact-with-all-contact-points = true
+}

--- a/docs-source/docs/modules/microservices-tutorial/examples/03-shopping-cart-service-java/src/test/resources/integration-test.conf
+++ b/docs-source/docs/modules/microservices-tutorial/examples/03-shopping-cart-service-java/src/test/resources/integration-test.conf
@@ -26,5 +26,12 @@ shopping-cart-service.grpc {
   interface = "localhost"
   // port = set by test per fixture
 }
+
 // akka.management.http.port = set by test per fixture
 // akka.discovery.config.services."shoppingcartservice".endpoints = set by test
+
+# don't self-join until all 3 have been started and probed sucessfully
+akka.management.cluster.bootstrap.contact-point-discovery {
+  required-contact-point-nr = 3
+  contact-with-all-contact-points = true
+}

--- a/docs-source/docs/modules/microservices-tutorial/examples/03-shopping-cart-service-scala/src/test/resources/integration-test.conf
+++ b/docs-source/docs/modules/microservices-tutorial/examples/03-shopping-cart-service-scala/src/test/resources/integration-test.conf
@@ -26,5 +26,12 @@ shopping-cart-service.grpc {
   interface = "localhost"
   // port = set by test per fixture
 }
+
 // akka.management.http.port = set by test per fixture
 // akka.discovery.config.services."shoppingcartservice".endpoints = set by test
+
+# don't self-join until all 3 have been started and probed sucessfully
+akka.management.cluster.bootstrap.contact-point-discovery {
+  required-contact-point-nr = 3
+  contact-with-all-contact-points = true
+}

--- a/docs-source/docs/modules/microservices-tutorial/examples/04-shopping-cart-service-java/src/test/resources/integration-test.conf
+++ b/docs-source/docs/modules/microservices-tutorial/examples/04-shopping-cart-service-java/src/test/resources/integration-test.conf
@@ -26,5 +26,12 @@ shopping-cart-service.grpc {
   interface = "localhost"
   // port = set by test per fixture
 }
+
 // akka.management.http.port = set by test per fixture
 // akka.discovery.config.services."shoppingcartservice".endpoints = set by test
+
+# don't self-join until all 3 have been started and probed sucessfully
+akka.management.cluster.bootstrap.contact-point-discovery {
+  required-contact-point-nr = 3
+  contact-with-all-contact-points = true
+}

--- a/docs-source/docs/modules/microservices-tutorial/examples/04-shopping-cart-service-scala/src/test/resources/integration-test.conf
+++ b/docs-source/docs/modules/microservices-tutorial/examples/04-shopping-cart-service-scala/src/test/resources/integration-test.conf
@@ -26,5 +26,12 @@ shopping-cart-service.grpc {
   interface = "localhost"
   // port = set by test per fixture
 }
+
 // akka.management.http.port = set by test per fixture
 // akka.discovery.config.services."shoppingcartservice".endpoints = set by test
+
+# don't self-join until all 3 have been started and probed sucessfully
+akka.management.cluster.bootstrap.contact-point-discovery {
+  required-contact-point-nr = 3
+  contact-with-all-contact-points = true
+}

--- a/docs-source/docs/modules/microservices-tutorial/examples/05-shopping-cart-service-java/src/test/resources/integration-test.conf
+++ b/docs-source/docs/modules/microservices-tutorial/examples/05-shopping-cart-service-java/src/test/resources/integration-test.conf
@@ -26,5 +26,12 @@ shopping-cart-service.grpc {
   interface = "localhost"
   // port = set by test per fixture
 }
+
 // akka.management.http.port = set by test per fixture
 // akka.discovery.config.services."shoppingcartservice".endpoints = set by test
+
+# don't self-join until all 3 have been started and probed sucessfully
+akka.management.cluster.bootstrap.contact-point-discovery {
+  required-contact-point-nr = 3
+  contact-with-all-contact-points = true
+}

--- a/docs-source/docs/modules/microservices-tutorial/examples/05-shopping-cart-service-scala/src/test/resources/integration-test.conf
+++ b/docs-source/docs/modules/microservices-tutorial/examples/05-shopping-cart-service-scala/src/test/resources/integration-test.conf
@@ -26,5 +26,12 @@ shopping-cart-service.grpc {
   interface = "localhost"
   // port = set by test per fixture
 }
+
 // akka.management.http.port = set by test per fixture
 // akka.discovery.config.services."shoppingcartservice".endpoints = set by test
+
+# don't self-join until all 3 have been started and probed sucessfully
+akka.management.cluster.bootstrap.contact-point-discovery {
+  required-contact-point-nr = 3
+  contact-with-all-contact-points = true
+}

--- a/docs-source/docs/modules/microservices-tutorial/examples/shopping-cart-service-java/src/test/resources/integration-test.conf
+++ b/docs-source/docs/modules/microservices-tutorial/examples/shopping-cart-service-java/src/test/resources/integration-test.conf
@@ -26,5 +26,12 @@ shopping-cart-service.grpc {
   interface = "localhost"
   // port = set by test per fixture
 }
+
 // akka.management.http.port = set by test per fixture
 // akka.discovery.config.services."shoppingcartservice".endpoints = set by test
+
+# don't self-join until all 3 have been started and probed sucessfully
+akka.management.cluster.bootstrap.contact-point-discovery {
+  required-contact-point-nr = 3
+  contact-with-all-contact-points = true
+}

--- a/docs-source/docs/modules/microservices-tutorial/examples/shopping-cart-service-scala/src/test/resources/integration-test.conf
+++ b/docs-source/docs/modules/microservices-tutorial/examples/shopping-cart-service-scala/src/test/resources/integration-test.conf
@@ -26,5 +26,12 @@ shopping-cart-service.grpc {
   interface = "localhost"
   // port = set by test per fixture
 }
+
 // akka.management.http.port = set by test per fixture
 // akka.discovery.config.services."shoppingcartservice".endpoints = set by test
+
+# don't self-join until all 3 have been started and probed sucessfully
+akka.management.cluster.bootstrap.contact-point-discovery {
+  required-contact-point-nr = 3
+  contact-with-all-contact-points = true
+}


### PR DESCRIPTION
IntegrationTest - expected:<42> but was:<84>

The problem was that two nodes self-joined, forming two separate clusters. The reason is that the local.conf (for local dev running) is quick but not safe when starting several at the same time, which is what the IntegrationTest is doing.

Log extract from the failing test:
```
>>> start IntegrationTest
2021-02-18T10:39:32.5879577Z Running shopping.cart.IntegrationTest

>> 34269 started
2021-02-18T10:39:33.4844458Z [2021-02-18 10:39:33,483] [INFO] [akka.management.cluster.bootstrap.ClusterBootstrap] [akka://IntegrationTest@127.0.0.1:34269] [] [IntegrationTest-akka.actor.default-dispatcher-13] - Using self contact point address: http://127.0.0.1:45527
2021-02-18T10:39:33.9987993Z [2021-02-18 10:39:33,993] [INFO] [akka.management.cluster.bootstrap.internal.BootstrapCoordinator] [akka://IntegrationTest@127.0.0.1:34269] [akkaBootstrapResolved] [IntegrationTest-akka.actor.default-dispatcher-11] - Located service members based on: [Lookup(shopping-cart-service,Some(management),Some(tcp))]: [ResolvedTarget(127.0.0.1,Some(45527),None), ResolvedTarget(127.0.0.1,Some(34577),None), ResolvedTarget(127.0.0.1,Some(45295),None)], filtered to [127.0.0.1:45527, 127.0.0.1:34577, 127.0.0.1:45295]

>> 33713 started
2021-02-18T10:39:34.7880332Z [2021-02-18 10:39:34,787] [INFO] [akka.management.cluster.bootstrap.ClusterBootstrap] [akka://IntegrationTest@127.0.0.1:33713] [] [IntegrationTest-akka.actor.default-dispatcher-6] - Using self contact point address: http://127.0.0.1:34577
2021-02-18T10:39:34.8273779Z [2021-02-18 10:39:34,825] [INFO] [akka.management.cluster.bootstrap.internal.BootstrapCoordinator] [akka://IntegrationTest@127.0.0.1:33713] [akkaBootstrapResolved] [IntegrationTest-akka.actor.default-dispatcher-3] - Located service members based on: [Lookup(shopping-cart-service,Some(management),Some(tcp))]: [ResolvedTarget(127.0.0.1,Some(45527),None), ResolvedTarget(127.0.0.1,Some(34577),None), ResolvedTarget(127.0.0.1,Some(45295),None)], filtered to [127.0.0.1:45527, 127.0.0.1:34577, 127.0.0.1:45295]

>>> 34269 self-join
2021-02-18T10:39:35.0396268Z [2021-02-18 10:39:35,038] [INFO] [akka.management.cluster.bootstrap.internal.BootstrapCoordinator] [akka://IntegrationTest@127.0.0.1:34269] [akkaBootstrapJoinSelf] [IntegrationTest-akka.actor.default-dispatcher-3] - Initiating new cluster, self-joining [akka://IntegrationTest@127.0.0.1:34269]. Other nodes are expected to locate this cluster via continued contact-point probing.

>> 44165 started
2021-02-18T10:39:35.2715497Z [2021-02-18 10:39:35,262] [INFO] [akka.management.cluster.bootstrap.ClusterBootstrap] [akka://IntegrationTest@127.0.0.1:44165] [] [IntegrationTest-akka.actor.default-dispatcher-7] - Using self contact point address: http://127.0.0.1:45295
2021-02-18T10:39:35.3065940Z [2021-02-18 10:39:35,305] [INFO] [akka.management.cluster.bootstrap.internal.BootstrapCoordinator] [akka://IntegrationTest@127.0.0.1:44165] [akkaBootstrapResolved] [IntegrationTest-akka.actor.default-dispatcher-12] - Located service members based on: [Lookup(shopping-cart-service,Some(management),Some(tcp))]: [ResolvedTarget(127.0.0.1,Some(45527),None), ResolvedTarget(127.0.0.1,Some(34577),None), ResolvedTarget(127.0.0.1,Some(45295),None)], filtered to [127.0.0.1:45527, 127.0.0.1:34577, 127.0.0.1:45295]

>>> 44165 joining 34269
2021-02-18T10:39:35.4994182Z [2021-02-18 10:39:35,485] [INFO] [akka.management.cluster.bootstrap.internal.BootstrapCoordinator] [akka://IntegrationTest@127.0.0.1:44165] [akkaBootstrapJoin] [IntegrationTest-akka.actor.default-dispatcher-16] - Joining [akka://IntegrationTest@127.0.0.1:44165] to existing cluster [akka://IntegrationTest@127.0.0.1:34269]

>>> 33713 self-join
2021-02-18T10:39:35.8359115Z [2021-02-18 10:39:35,832] [INFO] [akka.management.cluster.bootstrap.internal.BootstrapCoordinator] [akka://IntegrationTest@127.0.0.1:33713] [akkaBootstrapJoinSelf] [IntegrationTest-akka.actor.default-dispatcher-3] - Initiating new cluster, self-joining [akka://IntegrationTest@127.0.0.1:33713]. Other nodes are expected to locate this cluster via continued contact-point probing.
```

References #586
