### PR TITLE
Use non-primitive type for the Version field

### DIFF
--- a/docs-source/docs/modules/microservices-tutorial/examples/04-shopping-cart-service-java/src/main/java/shopping/cart/ItemPopularity.java
+++ b/docs-source/docs/modules/microservices-tutorial/examples/04-shopping-cart-service-java/src/main/java/shopping/cart/ItemPopularity.java
@@ -11,12 +11,13 @@ public class ItemPopularity {
   @Id private final String itemId;
 
   // optimistic locking
-  @Version private final long version;
+  @Version private final Long version;
 
   private final long count;
 
   public ItemPopularity() {
-    this.version = 0;
+    // null version means the entity is not on the DB
+    this.version = null;
     this.itemId = "";
     this.count = 0;
   }

--- a/docs-source/docs/modules/microservices-tutorial/examples/04-shopping-cart-service-java/src/main/java/shopping/cart/ItemPopularity.java
+++ b/docs-source/docs/modules/microservices-tutorial/examples/04-shopping-cart-service-java/src/main/java/shopping/cart/ItemPopularity.java
@@ -44,9 +44,4 @@ public class ItemPopularity {
     return new ItemPopularity(itemId, version, count + delta);
   }
 
-  @Transient
-  @JsonIgnore
-  boolean isNew() {
-    return itemId.equals("") || version <= 0;
-  }
 }

--- a/docs-source/docs/modules/microservices-tutorial/examples/04-shopping-cart-service-java/src/main/java/shopping/cart/ItemPopularity.java
+++ b/docs-source/docs/modules/microservices-tutorial/examples/04-shopping-cart-service-java/src/main/java/shopping/cart/ItemPopularity.java
@@ -1,6 +1,5 @@
 package shopping.cart;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import javax.persistence.*;
 
 @Entity
@@ -43,5 +42,4 @@ public class ItemPopularity {
   public ItemPopularity changeCount(long delta) {
     return new ItemPopularity(itemId, version, count + delta);
   }
-
 }

--- a/docs-source/docs/modules/microservices-tutorial/examples/04-shopping-cart-service-java/src/test/java/shopping/cart/ItemPopularityIntegrationTest.java
+++ b/docs-source/docs/modules/microservices-tutorial/examples/04-shopping-cart-service-java/src/test/java/shopping/cart/ItemPopularityIntegrationTest.java
@@ -138,13 +138,10 @@ public class ItemPopularityIntegrationTest {
 
     // ... when 99 concurrent carts add `item1`...
     for (int i = 1; i < cartCount; i++) {
-      System.out.print(".");
-      CompletionStage<ShoppingCart.Summary> rep =
-          sharding
-              .entityRefFor(ShoppingCart.ENTITY_KEY, "concurrent-cart" + i)
-              .askWithStatus(
-                  replyTo -> new ShoppingCart.AddItem(item, itemCount, replyTo), timeout);
-      rep.toCompletableFuture().get(3, SECONDS);
+      sharding
+          .entityRefFor(ShoppingCart.ENTITY_KEY, "concurrent-cart" + i)
+          .<ShoppingCart.Summary>askWithStatus(
+              replyTo -> new ShoppingCart.AddItem(item, itemCount, replyTo), timeout);
     }
 
     // ... then the popularity count is 100

--- a/docs-source/docs/modules/microservices-tutorial/examples/05-shopping-cart-service-java/src/main/java/shopping/cart/ItemPopularity.java
+++ b/docs-source/docs/modules/microservices-tutorial/examples/05-shopping-cart-service-java/src/main/java/shopping/cart/ItemPopularity.java
@@ -11,12 +11,13 @@ public class ItemPopularity {
   @Id private final String itemId;
 
   // optimistic locking
-  @Version private final long version;
+  @Version private final Long version;
 
   private final long count;
 
   public ItemPopularity() {
-    this.version = 0;
+    // null version means the entity is not on the DB
+    this.version = null;
     this.itemId = "";
     this.count = 0;
   }

--- a/docs-source/docs/modules/microservices-tutorial/examples/05-shopping-cart-service-java/src/main/java/shopping/cart/ItemPopularity.java
+++ b/docs-source/docs/modules/microservices-tutorial/examples/05-shopping-cart-service-java/src/main/java/shopping/cart/ItemPopularity.java
@@ -44,9 +44,4 @@ public class ItemPopularity {
     return new ItemPopularity(itemId, version, count + delta);
   }
 
-  @Transient
-  @JsonIgnore
-  boolean isNew() {
-    return itemId.equals("") || version <= 0;
-  }
 }

--- a/docs-source/docs/modules/microservices-tutorial/examples/05-shopping-cart-service-java/src/main/java/shopping/cart/ItemPopularity.java
+++ b/docs-source/docs/modules/microservices-tutorial/examples/05-shopping-cart-service-java/src/main/java/shopping/cart/ItemPopularity.java
@@ -1,6 +1,5 @@
 package shopping.cart;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import javax.persistence.*;
 
 @Entity
@@ -43,5 +42,4 @@ public class ItemPopularity {
   public ItemPopularity changeCount(long delta) {
     return new ItemPopularity(itemId, version, count + delta);
   }
-
 }

--- a/docs-source/docs/modules/microservices-tutorial/examples/05-shopping-cart-service-java/src/test/java/shopping/cart/ItemPopularityIntegrationTest.java
+++ b/docs-source/docs/modules/microservices-tutorial/examples/05-shopping-cart-service-java/src/test/java/shopping/cart/ItemPopularityIntegrationTest.java
@@ -138,13 +138,10 @@ public class ItemPopularityIntegrationTest {
 
     // ... when 99 concurrent carts add `item1`...
     for (int i = 1; i < cartCount; i++) {
-      System.out.print(".");
-      CompletionStage<ShoppingCart.Summary> rep =
-          sharding
-              .entityRefFor(ShoppingCart.ENTITY_KEY, "concurrent-cart" + i)
-              .askWithStatus(
-                  replyTo -> new ShoppingCart.AddItem(item, itemCount, replyTo), timeout);
-      rep.toCompletableFuture().get(3, SECONDS);
+      sharding
+          .entityRefFor(ShoppingCart.ENTITY_KEY, "concurrent-cart" + i)
+          .<ShoppingCart.Summary>askWithStatus(
+              replyTo -> new ShoppingCart.AddItem(item, itemCount, replyTo), timeout);
     }
 
     // ... then the popularity count is 100

--- a/docs-source/docs/modules/microservices-tutorial/examples/shopping-cart-service-java/src/main/java/shopping/cart/ItemPopularity.java
+++ b/docs-source/docs/modules/microservices-tutorial/examples/shopping-cart-service-java/src/main/java/shopping/cart/ItemPopularity.java
@@ -11,12 +11,13 @@ public class ItemPopularity {
   @Id private final String itemId;
 
   // optimistic locking
-  @Version private final long version;
+  @Version private final Long version;
 
   private final long count;
 
   public ItemPopularity() {
-    this.version = 0;
+    // null version means the entity is not on the DB
+    this.version = null;
     this.itemId = "";
     this.count = 0;
   }

--- a/docs-source/docs/modules/microservices-tutorial/examples/shopping-cart-service-java/src/main/java/shopping/cart/ItemPopularity.java
+++ b/docs-source/docs/modules/microservices-tutorial/examples/shopping-cart-service-java/src/main/java/shopping/cart/ItemPopularity.java
@@ -44,9 +44,4 @@ public class ItemPopularity {
     return new ItemPopularity(itemId, version, count + delta);
   }
 
-  @Transient
-  @JsonIgnore
-  boolean isNew() {
-    return itemId.equals("") || version <= 0;
-  }
 }

--- a/docs-source/docs/modules/microservices-tutorial/examples/shopping-cart-service-java/src/main/java/shopping/cart/ItemPopularity.java
+++ b/docs-source/docs/modules/microservices-tutorial/examples/shopping-cart-service-java/src/main/java/shopping/cart/ItemPopularity.java
@@ -1,6 +1,5 @@
 package shopping.cart;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import javax.persistence.*;
 
 @Entity
@@ -43,5 +42,4 @@ public class ItemPopularity {
   public ItemPopularity changeCount(long delta) {
     return new ItemPopularity(itemId, version, count + delta);
   }
-
 }

--- a/docs-source/docs/modules/microservices-tutorial/examples/shopping-cart-service-java/src/test/java/shopping/cart/ItemPopularityIntegrationTest.java
+++ b/docs-source/docs/modules/microservices-tutorial/examples/shopping-cart-service-java/src/test/java/shopping/cart/ItemPopularityIntegrationTest.java
@@ -138,13 +138,10 @@ public class ItemPopularityIntegrationTest {
 
     // ... when 99 concurrent carts add `item1`...
     for (int i = 1; i < cartCount; i++) {
-      System.out.print(".");
-      CompletionStage<ShoppingCart.Summary> rep =
-          sharding
-              .entityRefFor(ShoppingCart.ENTITY_KEY, "concurrent-cart" + i)
-              .askWithStatus(
-                  replyTo -> new ShoppingCart.AddItem(item, itemCount, replyTo), timeout);
-      rep.toCompletableFuture().get(3, SECONDS);
+      sharding
+          .entityRefFor(ShoppingCart.ENTITY_KEY, "concurrent-cart" + i)
+          .<ShoppingCart.Summary>askWithStatus(
+              replyTo -> new ShoppingCart.AddItem(item, itemCount, replyTo), timeout);
     }
 
     // ... then the popularity count is 100

--- a/scripts/copy-identical-files.sh
+++ b/scripts/copy-identical-files.sh
@@ -529,6 +529,10 @@ cp ${SRC} ${tutorial_root}/05-shopping-cart-service-scala/src/test/scala/shoppin
 cp ${SRC} ${tutorial_root}/04-shopping-cart-service-scala/src/test/scala/shopping/cart/
 
 # # java sources
+declare SRC="${tutorial_root}/shopping-cart-service-java/src/main/java/shopping/cart/ItemPopularity.java"
+cp ${SRC} ${tutorial_root}/05-shopping-cart-service-java/src/main/java/shopping/cart/
+cp ${SRC} ${tutorial_root}/04-shopping-cart-service-java/src/main/java/shopping/cart/
+
 declare SRC="${tutorial_root}/shopping-cart-service-java/src/main/java/shopping/cart/ItemPopularityProjection.java"
 cp ${SRC} ${tutorial_root}/05-shopping-cart-service-java/src/main/java/shopping/cart/
 cp ${SRC} ${tutorial_root}/04-shopping-cart-service-java/src/main/java/shopping/cart/


### PR DESCRIPTION
References #578 

From https://docs.spring.io/spring-data/jpa/docs/2.4.5/reference/html/#jpa.entity-persistence.saving-entites.strategies

> Version-Property and Id-Property inspection (default): By default Spring Data JPA inspects
>  first if there is a Version-property of non-primitive type. If there is, the entity is
>  considered new if the value of that property is null. Without such a Version-property Spring
>  Data JPA inspects the identifier property of the given entity. If the identifier property is
>  null, then the entity is assumed to be new. Otherwise, it is assumed to be not new.
