### PR TITLE
Prefer config-based over code for cluster bootstrap start

### DIFF
--- a/docs-source/docs/modules/how-to/examples/cleanup-dependencies-project/build.sbt
+++ b/docs-source/docs/modules/how-to/examples/cleanup-dependencies-project/build.sbt
@@ -27,7 +27,7 @@ Global / cancelable := false // ctrl-c
 
 val AkkaVersion = "2.6.13"
 val AkkaHttpVersion = "10.2.3"
-val AkkaManagementVersion = "1.0.9"
+val AkkaManagementVersion = "1.0.10"
 
 // tag::remove-akka-persistence-cassandra-version[]
 val AkkaPersistenceCassandraVersion = "1.0.4"

--- a/docs-source/docs/modules/how-to/examples/shopping-cart-service-cassandra-java/pom.xml
+++ b/docs-source/docs/modules/how-to/examples/shopping-cart-service-cassandra-java/pom.xml
@@ -22,7 +22,7 @@
         <scala.binary.version>2.13</scala.binary.version>
         <akka.version>2.6.13</akka.version>
         <akka-http.version>10.2.2</akka-http.version>
-        <akka-management.version>1.0.9</akka-management.version>
+        <akka-management.version>1.0.10</akka-management.version>
         <!-- tag::akka-persistence-cassandra[] -->
         <akka-persistence-cassandra.version>1.0.4</akka-persistence-cassandra.version>
         <!-- end::akka-persistence-cassandra[] -->

--- a/docs-source/docs/modules/how-to/examples/shopping-cart-service-cassandra-java/src/main/java/shopping/cart/Main.java
+++ b/docs-source/docs/modules/how-to/examples/shopping-cart-service-cassandra-java/src/main/java/shopping/cart/Main.java
@@ -29,9 +29,6 @@ public class Main {
   }
 
   public static void init(ActorSystem<Void> system, ShoppingOrderService orderService) {
-    AkkaManagement.get(system).start();
-    ClusterBootstrap.get(system).start();
-
     ShoppingCart.init(system);
 
     // tag::ItemPopularityProjection[]

--- a/docs-source/docs/modules/how-to/examples/shopping-cart-service-cassandra-scala/build.sbt
+++ b/docs-source/docs/modules/how-to/examples/shopping-cart-service-cassandra-scala/build.sbt
@@ -25,7 +25,7 @@ Global / cancelable := false // ctrl-c
 
 val AkkaVersion = "2.6.13"
 val AkkaHttpVersion = "10.2.3"
-val AkkaManagementVersion = "1.0.9"
+val AkkaManagementVersion = "1.0.10"
 // tag::akka-persistence-cassandra[]
 val AkkaPersistenceCassandraVersion = "1.0.4"
 

--- a/docs-source/docs/modules/how-to/examples/shopping-cart-service-cassandra-scala/src/main/scala/shopping/cart/Main.scala
+++ b/docs-source/docs/modules/how-to/examples/shopping-cart-service-cassandra-scala/src/main/scala/shopping/cart/Main.scala
@@ -31,9 +31,6 @@ object Main {
   }
 
   def init(system: ActorSystem[_], orderService: ShoppingOrderService): Unit = {
-    AkkaManagement(system).start()
-    ClusterBootstrap(system).start()
-
     ShoppingCart.init(system)
 
     // tag::ItemPopularityProjection[]

--- a/docs-source/docs/modules/how-to/examples/shopping-cart-service-java/pom.xml
+++ b/docs-source/docs/modules/how-to/examples/shopping-cart-service-java/pom.xml
@@ -20,7 +20,7 @@
         <scala.binary.version>2.13</scala.binary.version>
         <akka.version>2.6.13</akka.version>
         <akka-http.version>10.2.2</akka-http.version>
-        <akka-management.version>1.0.9</akka-management.version>
+        <akka-management.version>1.0.10</akka-management.version>
         <alpakka-kafka.version>2.0.6</alpakka-kafka.version>
         <akka-projection.version>1.1.0</akka-projection.version>
         <akka-persistence-jdbc.version>5.0.0</akka-persistence-jdbc.version>

--- a/docs-source/docs/modules/how-to/examples/shopping-cart-service-java/src/main/java/shopping/cart/Main.java
+++ b/docs-source/docs/modules/how-to/examples/shopping-cart-service-java/src/main/java/shopping/cart/Main.java
@@ -13,16 +13,11 @@ public class Main {
   public static void main(String[] args) {
     ActorSystem<Void> system = ActorSystem.create(Behaviors.empty(), "ShoppingCartService");
     try {
-      init(system);
+      AkkaManagement.get(system).start();
     } catch (Exception e) {
       logger.error("Terminating due to initialization failure.", e);
       system.terminate();
     }
   }
 
-  public static void init(ActorSystem<Void> system) {
-    // tag::start-akka-management[]
-    AkkaManagement.get(system).start();
-    // tag::start-akka-management[]
-  }
 }

--- a/docs-source/docs/modules/how-to/examples/shopping-cart-service-scala/build.sbt
+++ b/docs-source/docs/modules/how-to/examples/shopping-cart-service-scala/build.sbt
@@ -26,7 +26,7 @@ Global / cancelable := false // ctrl-c
 val AkkaVersion = "2.6.13"
 // tag::dependencies-for-healthchecks[]
 val AkkaHttpVersion = "10.2.3"
-val AkkaManagementVersion = "1.0.9"
+val AkkaManagementVersion = "1.0.10"
 // end::dependencies-for-healthchecks[]
 val AkkaPersistenceCassandraVersion = "1.0.4"
 val AlpakkaKafkaVersion = "2.0.6"

--- a/docs-source/docs/modules/how-to/examples/shopping-cart-service-scala/src/main/scala/shopping/cart/Main.scala
+++ b/docs-source/docs/modules/how-to/examples/shopping-cart-service-scala/src/main/scala/shopping/cart/Main.scala
@@ -13,18 +13,12 @@ object Main {
   def main(args: Array[String]): Unit = {
     val system = ActorSystem[Nothing](Behaviors.empty, "ShoppingCartService")
     try {
-      init(system)
+      AkkaManagement(system).start()
     } catch {
       case NonFatal(e) =>
         logger.error("Terminating due to initialization failure.", e)
         system.terminate()
     }
-  }
-
-  def init(system: ActorSystem[_]): Unit = {
-    // tag::start-akka-management[]
-    AkkaManagement(system).start()
-    // end::start-akka-management[]
   }
 
 }

--- a/docs-source/docs/modules/how-to/pages/health-checks.adoc
+++ b/docs-source/docs/modules/how-to/pages/health-checks.adoc
@@ -31,19 +31,25 @@ Upon start Akka Management creates an HTTP endpoint that allows insight into the
 .src/main/resources/application.conf
 [source,hocon]
 ----
+akka.extensions += "akka.management.cluster.bootstrap.ClusterBootstrap" # <1>
 akka.management {
-  http {
+  http { # <2>
     hostname = "127.0.0.1"
     port = 8558
   }
 }
 ----
 
-The management endpoint starts on the configured interface and port.
+<1> Initialization of Cluster Bootstrap that is used for forming the Akka Cluster. This extension, in turn, also start the Akka Management extension.
+<2> Set up the interface and port for Akka Management's HTTP server.
 
-[source,scala,indent=0]
+If you want to start the Akka Management extension without bootstrapping a cluster, you need to start the Akka
+Management extension programmatically:
+
+.src/main/scala/shopping/cart/Main.scala
+[source,scala]
 ----
-include::example$shopping-cart-service-scala/src/main/scala/shopping/cart/Main.scala[tag=start-akka-management]
+AkkaManagement(system).start()
 ----
 
 We consider our service ready for requests when it has joined the Akka Cluster and the database can be reached. Akka Management's "cluster HTTP" module automatically enables a check for cluster membership.

--- a/docs-source/docs/modules/microservices-tutorial/examples/00-shopping-analytics-service-java/pom.xml
+++ b/docs-source/docs/modules/microservices-tutorial/examples/00-shopping-analytics-service-java/pom.xml
@@ -20,7 +20,7 @@
         <scala.binary.version>2.13</scala.binary.version>
         <akka.version>2.6.13</akka.version>
         <akka-http.version>10.2.3</akka-http.version>
-        <akka-management.version>1.0.9</akka-management.version>
+        <akka-management.version>1.0.10</akka-management.version>
         <alpakka-kafka.version>2.0.6</alpakka-kafka.version>
         <akka-projection.version>1.1.0</akka-projection.version>
         <akka-persistence-jdbc.version>5.0.0</akka-persistence-jdbc.version>

--- a/docs-source/docs/modules/microservices-tutorial/examples/00-shopping-analytics-service-java/src/main/java/shopping/analytics/Main.java
+++ b/docs-source/docs/modules/microservices-tutorial/examples/00-shopping-analytics-service-java/src/main/java/shopping/analytics/Main.java
@@ -13,16 +13,6 @@ public class Main {
 
   public static void main(String[] args) {
     ActorSystem<Void> system = ActorSystem.create(Behaviors.empty(), "ShoppingAnalyticsService");
-    try {
-      init(system);
-    } catch (Exception e) {
-      logger.error("Terminating due to initialization failure.", e);
-      system.terminate();
-    }
   }
 
-  public static void init(ActorSystem<Void> system) {
-    AkkaManagement.get(system).start();
-    ClusterBootstrap.get(system).start();
-  }
 }

--- a/docs-source/docs/modules/microservices-tutorial/examples/00-shopping-analytics-service-scala/build.sbt
+++ b/docs-source/docs/modules/microservices-tutorial/examples/00-shopping-analytics-service-scala/build.sbt
@@ -27,7 +27,7 @@ Global / cancelable := false // ctrl-c
 
 val AkkaVersion = "2.6.13"
 val AkkaHttpVersion = "10.2.3"
-val AkkaManagementVersion = "1.0.9"
+val AkkaManagementVersion = "1.0.10"
 val AkkaPersistenceJdbcVersion = "5.0.0"
 val AlpakkaKafkaVersion = "2.0.6"
 val AkkaProjectionVersion = "1.1.0"

--- a/docs-source/docs/modules/microservices-tutorial/examples/00-shopping-analytics-service-scala/src/main/scala/shopping/analytics/Main.scala
+++ b/docs-source/docs/modules/microservices-tutorial/examples/00-shopping-analytics-service-scala/src/main/scala/shopping/analytics/Main.scala
@@ -14,18 +14,6 @@ object Main {
   def main(args: Array[String]): Unit = {
     val system =
       ActorSystem[Nothing](Behaviors.empty, "ShoppingAnalyticsService")
-    try {
-      init(system)
-    } catch {
-      case NonFatal(e) =>
-        logger.error("Terminating due to initialization failure.", e)
-        system.terminate()
-    }
-  }
-
-  def init(system: ActorSystem[_]): Unit = {
-    AkkaManagement(system).start()
-    ClusterBootstrap(system).start()
   }
 
 }

--- a/docs-source/docs/modules/microservices-tutorial/examples/00-shopping-cart-service-java/pom.xml
+++ b/docs-source/docs/modules/microservices-tutorial/examples/00-shopping-cart-service-java/pom.xml
@@ -20,7 +20,7 @@
         <scala.binary.version>2.13</scala.binary.version>
         <akka.version>2.6.13</akka.version>
         <akka-http.version>10.2.2</akka-http.version>
-        <akka-management.version>1.0.9</akka-management.version>
+        <akka-management.version>1.0.10</akka-management.version>
         <alpakka-kafka.version>2.0.6</alpakka-kafka.version>
         <akka-projection.version>1.1.0</akka-projection.version>
         <akka-persistence-jdbc.version>5.0.0</akka-persistence-jdbc.version>

--- a/docs-source/docs/modules/microservices-tutorial/examples/00-shopping-cart-service-java/src/main/java/shopping/cart/Main.java
+++ b/docs-source/docs/modules/microservices-tutorial/examples/00-shopping-cart-service-java/src/main/java/shopping/cart/Main.java
@@ -13,16 +13,6 @@ public class Main {
 
   public static void main(String[] args) {
     ActorSystem<Void> system = ActorSystem.create(Behaviors.empty(), "ShoppingCartService");
-    try {
-      init(system);
-    } catch (Exception e) {
-      logger.error("Terminating due to initialization failure.", e);
-      system.terminate();
-    }
   }
 
-  public static void init(ActorSystem<Void> system) {
-    AkkaManagement.get(system).start();
-    ClusterBootstrap.get(system).start();
-  }
 }

--- a/docs-source/docs/modules/microservices-tutorial/examples/00-shopping-cart-service-scala/build.sbt
+++ b/docs-source/docs/modules/microservices-tutorial/examples/00-shopping-cart-service-scala/build.sbt
@@ -27,7 +27,7 @@ Global / cancelable := false // ctrl-c
 
 val AkkaVersion = "2.6.13"
 val AkkaHttpVersion = "10.2.3"
-val AkkaManagementVersion = "1.0.9"
+val AkkaManagementVersion = "1.0.10"
 val AkkaPersistenceJdbcVersion = "5.0.0"
 val AlpakkaKafkaVersion = "2.0.6"
 val AkkaProjectionVersion = "1.1.0"

--- a/docs-source/docs/modules/microservices-tutorial/examples/00-shopping-cart-service-scala/src/main/scala/shopping/cart/Main.scala
+++ b/docs-source/docs/modules/microservices-tutorial/examples/00-shopping-cart-service-scala/src/main/scala/shopping/cart/Main.scala
@@ -13,18 +13,6 @@ object Main {
 
   def main(args: Array[String]): Unit = {
     val system = ActorSystem[Nothing](Behaviors.empty, "ShoppingCartService")
-    try {
-      init(system)
-    } catch {
-      case NonFatal(e) =>
-        logger.error("Terminating due to initialization failure.", e)
-        system.terminate()
-    }
-  }
-
-  def init(system: ActorSystem[_]): Unit = {
-    AkkaManagement(system).start()
-    ClusterBootstrap(system).start()
   }
 
 }

--- a/docs-source/docs/modules/microservices-tutorial/examples/00-shopping-order-service-java/pom.xml
+++ b/docs-source/docs/modules/microservices-tutorial/examples/00-shopping-order-service-java/pom.xml
@@ -20,7 +20,7 @@
         <scala.binary.version>2.13</scala.binary.version>
         <akka.version>2.6.13</akka.version>
         <akka-http.version>10.2.2</akka-http.version>
-        <akka-management.version>1.0.9</akka-management.version>
+        <akka-management.version>1.0.10</akka-management.version>
         <alpakka-kafka.version>2.0.6</alpakka-kafka.version>
         <akka-projection.version>1.1.0</akka-projection.version>
         <akka-persistence-jdbc.version>5.0.0</akka-persistence-jdbc.version>

--- a/docs-source/docs/modules/microservices-tutorial/examples/00-shopping-order-service-java/src/main/java/shopping/order/Main.java
+++ b/docs-source/docs/modules/microservices-tutorial/examples/00-shopping-order-service-java/src/main/java/shopping/order/Main.java
@@ -13,16 +13,5 @@ public class Main {
 
   public static void main(String[] args) throws Exception {
     ActorSystem<Void> system = ActorSystem.create(Behaviors.empty(), "ShoppingOrderService");
-    try {
-      init(system);
-    } catch (Exception e) {
-      logger.error("Terminating due to initialization failure.", e);
-      system.terminate();
-    }
-  }
-
-  public static void init(ActorSystem<Void> system) {
-    AkkaManagement.get(system).start();
-    ClusterBootstrap.get(system).start();
   }
 }

--- a/docs-source/docs/modules/microservices-tutorial/examples/00-shopping-order-service-scala/build.sbt
+++ b/docs-source/docs/modules/microservices-tutorial/examples/00-shopping-order-service-scala/build.sbt
@@ -27,7 +27,7 @@ Global / cancelable := false // ctrl-c
 
 val AkkaVersion = "2.6.13"
 val AkkaHttpVersion = "10.2.3"
-val AkkaManagementVersion = "1.0.9"
+val AkkaManagementVersion = "1.0.10"
 val AkkaPersistenceJdbcVersion = "5.0.0"
 val AlpakkaKafkaVersion = "2.0.6"
 val AkkaProjectionVersion = "1.1.0"

--- a/docs-source/docs/modules/microservices-tutorial/examples/00-shopping-order-service-scala/src/main/scala/shopping/order/Main.scala
+++ b/docs-source/docs/modules/microservices-tutorial/examples/00-shopping-order-service-scala/src/main/scala/shopping/order/Main.scala
@@ -13,18 +13,6 @@ object Main {
 
   def main(args: Array[String]): Unit = {
     val system = ActorSystem[Nothing](Behaviors.empty, "ShoppingOrderService")
-    try {
-      init(system)
-    } catch {
-      case NonFatal(e) =>
-        logger.error("Terminating due to initialization failure.", e)
-        system.terminate()
-    }
-  }
-
-  def init(system: ActorSystem[_]): Unit = {
-    AkkaManagement(system).start()
-    ClusterBootstrap(system).start()
   }
 
 }

--- a/docs-source/docs/modules/microservices-tutorial/examples/01-shopping-cart-service-java/pom.xml
+++ b/docs-source/docs/modules/microservices-tutorial/examples/01-shopping-cart-service-java/pom.xml
@@ -20,7 +20,7 @@
         <scala.binary.version>2.13</scala.binary.version>
         <akka.version>2.6.13</akka.version>
         <akka-http.version>10.2.2</akka-http.version>
-        <akka-management.version>1.0.9</akka-management.version>
+        <akka-management.version>1.0.10</akka-management.version>
         <alpakka-kafka.version>2.0.6</alpakka-kafka.version>
         <akka-projection.version>1.1.0</akka-projection.version>
         <akka-persistence-jdbc.version>5.0.0</akka-persistence-jdbc.version>

--- a/docs-source/docs/modules/microservices-tutorial/examples/01-shopping-cart-service-java/src/main/java/shopping/cart/Main.java
+++ b/docs-source/docs/modules/microservices-tutorial/examples/01-shopping-cart-service-java/src/main/java/shopping/cart/Main.java
@@ -24,13 +24,10 @@ public class Main {
   }
 
   public static void init(ActorSystem<Void> system) {
-    AkkaManagement.get(system).start(); // <2>
-    ClusterBootstrap.get(system).start();
-
     Config config = system.settings().config();
     String grpcInterface = config.getString("shopping-cart-service.grpc.interface");
     int grpcPort = config.getInt("shopping-cart-service.grpc.port");
     ShoppingCartService grpcService = new ShoppingCartServiceImpl();
-    ShoppingCartServer.start(grpcInterface, grpcPort, system, grpcService); // <3>
+    ShoppingCartServer.start(grpcInterface, grpcPort, system, grpcService); // <2>
   }
 }

--- a/docs-source/docs/modules/microservices-tutorial/examples/01-shopping-cart-service-scala/build.sbt
+++ b/docs-source/docs/modules/microservices-tutorial/examples/01-shopping-cart-service-scala/build.sbt
@@ -27,7 +27,7 @@ Global / cancelable := false // ctrl-c
 
 val AkkaVersion = "2.6.13"
 val AkkaHttpVersion = "10.2.3"
-val AkkaManagementVersion = "1.0.9"
+val AkkaManagementVersion = "1.0.10"
 val AkkaPersistenceJdbcVersion = "5.0.0"
 val AlpakkaKafkaVersion = "2.0.6"
 val AkkaProjectionVersion = "1.1.0"

--- a/docs-source/docs/modules/microservices-tutorial/examples/01-shopping-cart-service-scala/src/main/scala/shopping/cart/Main.scala
+++ b/docs-source/docs/modules/microservices-tutorial/examples/01-shopping-cart-service-scala/src/main/scala/shopping/cart/Main.scala
@@ -24,9 +24,6 @@ object Main {
   }
 
   def init(system: ActorSystem[_]): Unit = {
-    AkkaManagement(system).start()
-    ClusterBootstrap(system).start()
-
     val grpcInterface =
       system.settings.config.getString("shopping-cart-service.grpc.interface")
     val grpcPort =

--- a/docs-source/docs/modules/microservices-tutorial/examples/01-shopping-cart-service-scala/src/main/scala/shopping/cart/Main.scala
+++ b/docs-source/docs/modules/microservices-tutorial/examples/01-shopping-cart-service-scala/src/main/scala/shopping/cart/Main.scala
@@ -24,7 +24,7 @@ object Main {
   }
 
   def init(system: ActorSystem[_]): Unit = {
-    AkkaManagement(system).start() // <2>
+    AkkaManagement(system).start()
     ClusterBootstrap(system).start()
 
     val grpcInterface =
@@ -37,7 +37,7 @@ object Main {
       grpcPort,
       system,
       grpcService
-    ) // <3>
+    ) // <2>
   }
 
 }

--- a/docs-source/docs/modules/microservices-tutorial/examples/02-shopping-cart-service-java/pom.xml
+++ b/docs-source/docs/modules/microservices-tutorial/examples/02-shopping-cart-service-java/pom.xml
@@ -20,7 +20,7 @@
         <scala.binary.version>2.13</scala.binary.version>
         <akka.version>2.6.13</akka.version>
         <akka-http.version>10.2.2</akka-http.version>
-        <akka-management.version>1.0.9</akka-management.version>
+        <akka-management.version>1.0.10</akka-management.version>
         <alpakka-kafka.version>2.0.6</alpakka-kafka.version>
         <akka-projection.version>1.1.0</akka-projection.version>
         <akka-persistence-jdbc.version>5.0.0</akka-persistence-jdbc.version>

--- a/docs-source/docs/modules/microservices-tutorial/examples/02-shopping-cart-service-java/src/main/java/shopping/cart/Main.java
+++ b/docs-source/docs/modules/microservices-tutorial/examples/02-shopping-cart-service-java/src/main/java/shopping/cart/Main.java
@@ -24,9 +24,6 @@ public class Main {
   }
 
   public static void init(ActorSystem<Void> system) {
-    AkkaManagement.get(system).start();
-    ClusterBootstrap.get(system).start();
-
     // tag::ShoppingCart[]
     ShoppingCart.init(system);
     // end::ShoppingCart[]

--- a/docs-source/docs/modules/microservices-tutorial/examples/02-shopping-cart-service-scala/build.sbt
+++ b/docs-source/docs/modules/microservices-tutorial/examples/02-shopping-cart-service-scala/build.sbt
@@ -27,7 +27,7 @@ Global / cancelable := false // ctrl-c
 
 val AkkaVersion = "2.6.13"
 val AkkaHttpVersion = "10.2.3"
-val AkkaManagementVersion = "1.0.9"
+val AkkaManagementVersion = "1.0.10"
 val AkkaPersistenceJdbcVersion = "5.0.0"
 val AlpakkaKafkaVersion = "2.0.6"
 val AkkaProjectionVersion = "1.1.0"

--- a/docs-source/docs/modules/microservices-tutorial/examples/02-shopping-cart-service-scala/src/main/scala/shopping/cart/Main.scala
+++ b/docs-source/docs/modules/microservices-tutorial/examples/02-shopping-cart-service-scala/src/main/scala/shopping/cart/Main.scala
@@ -24,9 +24,6 @@ object Main {
   }
 
   def init(system: ActorSystem[_]): Unit = {
-    AkkaManagement(system).start()
-    ClusterBootstrap(system).start()
-
     // tag::ShoppingCart[]
     ShoppingCart.init(system)
     // end::ShoppingCart[]

--- a/docs-source/docs/modules/microservices-tutorial/examples/03-shopping-cart-service-java/pom.xml
+++ b/docs-source/docs/modules/microservices-tutorial/examples/03-shopping-cart-service-java/pom.xml
@@ -20,7 +20,7 @@
         <scala.binary.version>2.13</scala.binary.version>
         <akka.version>2.6.13</akka.version>
         <akka-http.version>10.2.2</akka-http.version>
-        <akka-management.version>1.0.9</akka-management.version>
+        <akka-management.version>1.0.10</akka-management.version>
         <alpakka-kafka.version>2.0.6</alpakka-kafka.version>
         <akka-projection.version>1.1.0</akka-projection.version>
         <akka-persistence-jdbc.version>5.0.0</akka-persistence-jdbc.version>

--- a/docs-source/docs/modules/microservices-tutorial/examples/03-shopping-cart-service-java/src/main/java/shopping/cart/Main.java
+++ b/docs-source/docs/modules/microservices-tutorial/examples/03-shopping-cart-service-java/src/main/java/shopping/cart/Main.java
@@ -24,9 +24,6 @@ public class Main {
   }
 
   public static void init(ActorSystem<Void> system) {
-    AkkaManagement.get(system).start();
-    ClusterBootstrap.get(system).start();
-
     ShoppingCart.init(system);
 
     Config config = system.settings().config();

--- a/docs-source/docs/modules/microservices-tutorial/examples/03-shopping-cart-service-scala/build.sbt
+++ b/docs-source/docs/modules/microservices-tutorial/examples/03-shopping-cart-service-scala/build.sbt
@@ -27,7 +27,7 @@ Global / cancelable := false // ctrl-c
 
 val AkkaVersion = "2.6.13"
 val AkkaHttpVersion = "10.2.3"
-val AkkaManagementVersion = "1.0.9"
+val AkkaManagementVersion = "1.0.10"
 val AkkaPersistenceJdbcVersion = "5.0.0"
 val AlpakkaKafkaVersion = "2.0.6"
 val AkkaProjectionVersion = "1.1.0"

--- a/docs-source/docs/modules/microservices-tutorial/examples/03-shopping-cart-service-scala/src/main/scala/shopping/cart/Main.scala
+++ b/docs-source/docs/modules/microservices-tutorial/examples/03-shopping-cart-service-scala/src/main/scala/shopping/cart/Main.scala
@@ -24,9 +24,6 @@ object Main {
   }
 
   def init(system: ActorSystem[_]): Unit = {
-    AkkaManagement(system).start()
-    ClusterBootstrap(system).start()
-
     ShoppingCart.init(system)
 
     val grpcInterface =

--- a/docs-source/docs/modules/microservices-tutorial/examples/04-shopping-cart-service-java/pom.xml
+++ b/docs-source/docs/modules/microservices-tutorial/examples/04-shopping-cart-service-java/pom.xml
@@ -20,7 +20,7 @@
         <scala.binary.version>2.13</scala.binary.version>
         <akka.version>2.6.13</akka.version>
         <akka-http.version>10.2.2</akka-http.version>
-        <akka-management.version>1.0.9</akka-management.version>
+        <akka-management.version>1.0.10</akka-management.version>
         <alpakka-kafka.version>2.0.6</alpakka-kafka.version>
         <akka-projection.version>1.1.0</akka-projection.version>
         <akka-persistence-jdbc.version>5.0.0</akka-persistence-jdbc.version>

--- a/docs-source/docs/modules/microservices-tutorial/examples/04-shopping-cart-service-java/src/main/java/shopping/cart/Main.java
+++ b/docs-source/docs/modules/microservices-tutorial/examples/04-shopping-cart-service-java/src/main/java/shopping/cart/Main.java
@@ -28,9 +28,6 @@ public class Main {
   }
 
   public static void init(ActorSystem<Void> system) {
-    AkkaManagement.get(system).start();
-    ClusterBootstrap.get(system).start();
-
     ShoppingCart.init(system);
 
     // tag::ItemPopularityProjection[]

--- a/docs-source/docs/modules/microservices-tutorial/examples/04-shopping-cart-service-scala/build.sbt
+++ b/docs-source/docs/modules/microservices-tutorial/examples/04-shopping-cart-service-scala/build.sbt
@@ -27,7 +27,7 @@ Global / cancelable := false // ctrl-c
 
 val AkkaVersion = "2.6.13"
 val AkkaHttpVersion = "10.2.3"
-val AkkaManagementVersion = "1.0.9"
+val AkkaManagementVersion = "1.0.10"
 val AkkaPersistenceJdbcVersion = "5.0.0"
 val AlpakkaKafkaVersion = "2.0.6"
 val AkkaProjectionVersion = "1.1.0"

--- a/docs-source/docs/modules/microservices-tutorial/examples/04-shopping-cart-service-scala/src/main/scala/shopping/cart/Main.scala
+++ b/docs-source/docs/modules/microservices-tutorial/examples/04-shopping-cart-service-scala/src/main/scala/shopping/cart/Main.scala
@@ -30,9 +30,6 @@ object Main {
     ScalikeJdbcSetup.init(system) // <1>
     // end::ItemPopularityProjection[]
 
-    AkkaManagement(system).start()
-    ClusterBootstrap(system).start()
-
     ShoppingCart.init(system)
 
     // tag::ItemPopularityProjection[]

--- a/docs-source/docs/modules/microservices-tutorial/examples/05-shopping-cart-service-java/pom.xml
+++ b/docs-source/docs/modules/microservices-tutorial/examples/05-shopping-cart-service-java/pom.xml
@@ -20,7 +20,7 @@
         <scala.binary.version>2.13</scala.binary.version>
         <akka.version>2.6.13</akka.version>
         <akka-http.version>10.2.2</akka-http.version>
-        <akka-management.version>1.0.9</akka-management.version>
+        <akka-management.version>1.0.10</akka-management.version>
         <alpakka-kafka.version>2.0.6</alpakka-kafka.version>
         <akka-projection.version>1.1.0</akka-projection.version>
         <akka-persistence-jdbc.version>5.0.0</akka-persistence-jdbc.version>

--- a/docs-source/docs/modules/microservices-tutorial/examples/05-shopping-cart-service-java/src/main/java/shopping/cart/Main.java
+++ b/docs-source/docs/modules/microservices-tutorial/examples/05-shopping-cart-service-java/src/main/java/shopping/cart/Main.java
@@ -28,9 +28,6 @@ public class Main {
   }
 
   public static void init(ActorSystem<Void> system) {
-    AkkaManagement.get(system).start();
-    ClusterBootstrap.get(system).start();
-
     ShoppingCart.init(system);
 
     ApplicationContext springContext = SpringIntegration.applicationContext(system);

--- a/docs-source/docs/modules/microservices-tutorial/examples/05-shopping-cart-service-scala/build.sbt
+++ b/docs-source/docs/modules/microservices-tutorial/examples/05-shopping-cart-service-scala/build.sbt
@@ -27,7 +27,7 @@ Global / cancelable := false // ctrl-c
 
 val AkkaVersion = "2.6.13"
 val AkkaHttpVersion = "10.2.3"
-val AkkaManagementVersion = "1.0.9"
+val AkkaManagementVersion = "1.0.10"
 val AkkaPersistenceJdbcVersion = "5.0.0"
 val AlpakkaKafkaVersion = "2.0.6"
 val AkkaProjectionVersion = "1.1.0"

--- a/docs-source/docs/modules/microservices-tutorial/examples/05-shopping-cart-service-scala/src/main/scala/shopping/cart/Main.scala
+++ b/docs-source/docs/modules/microservices-tutorial/examples/05-shopping-cart-service-scala/src/main/scala/shopping/cart/Main.scala
@@ -28,9 +28,6 @@ object Main {
   def init(system: ActorSystem[_]): Unit = {
     ScalikeJdbcSetup.init(system)
 
-    AkkaManagement(system).start()
-    ClusterBootstrap(system).start()
-
     ShoppingCart.init(system)
 
     val itemPopularityRepository = new ItemPopularityRepositoryImpl()

--- a/docs-source/docs/modules/microservices-tutorial/examples/shopping-analytics-service-java/pom.xml
+++ b/docs-source/docs/modules/microservices-tutorial/examples/shopping-analytics-service-java/pom.xml
@@ -20,7 +20,7 @@
         <scala.binary.version>2.13</scala.binary.version>
         <akka.version>2.6.13</akka.version>
         <akka-http.version>10.2.3</akka-http.version>
-        <akka-management.version>1.0.9</akka-management.version>
+        <akka-management.version>1.0.10</akka-management.version>
         <alpakka-kafka.version>2.0.6</alpakka-kafka.version>
         <akka-projection.version>1.1.0</akka-projection.version>
         <akka-persistence-jdbc.version>5.0.0</akka-persistence-jdbc.version>

--- a/docs-source/docs/modules/microservices-tutorial/examples/shopping-analytics-service-java/src/main/java/shopping/analytics/Main.java
+++ b/docs-source/docs/modules/microservices-tutorial/examples/shopping-analytics-service-java/src/main/java/shopping/analytics/Main.java
@@ -22,9 +22,6 @@ public class Main {
   }
 
   public static void init(ActorSystem<Void> system) {
-    AkkaManagement.get(system).start();
-    ClusterBootstrap.get(system).start();
-
     ShoppingCartEventConsumer.init(system);
   }
 }

--- a/docs-source/docs/modules/microservices-tutorial/examples/shopping-analytics-service-scala/build.sbt
+++ b/docs-source/docs/modules/microservices-tutorial/examples/shopping-analytics-service-scala/build.sbt
@@ -27,7 +27,7 @@ Global / cancelable := false // ctrl-c
 
 val AkkaVersion = "2.6.13"
 val AkkaHttpVersion = "10.2.3"
-val AkkaManagementVersion = "1.0.9"
+val AkkaManagementVersion = "1.0.10"
 val AkkaPersistenceJdbcVersion = "5.0.0"
 val AlpakkaKafkaVersion = "2.0.6"
 val AkkaProjectionVersion = "1.1.0"

--- a/docs-source/docs/modules/microservices-tutorial/examples/shopping-analytics-service-scala/src/main/scala/shopping/analytics/Main.scala
+++ b/docs-source/docs/modules/microservices-tutorial/examples/shopping-analytics-service-scala/src/main/scala/shopping/analytics/Main.scala
@@ -24,9 +24,6 @@ object Main {
   }
 
   def init(system: ActorSystem[_]): Unit = {
-    AkkaManagement(system).start()
-    ClusterBootstrap(system).start()
-
     ShoppingCartEventConsumer.init(system)
   }
 

--- a/docs-source/docs/modules/microservices-tutorial/examples/shopping-cart-service-java/pom.xml
+++ b/docs-source/docs/modules/microservices-tutorial/examples/shopping-cart-service-java/pom.xml
@@ -20,7 +20,7 @@
         <scala.binary.version>2.13</scala.binary.version>
         <akka.version>2.6.13</akka.version>
         <akka-http.version>10.2.2</akka-http.version>
-        <akka-management.version>1.0.9</akka-management.version>
+        <akka-management.version>1.0.10</akka-management.version>
         <alpakka-kafka.version>2.0.6</alpakka-kafka.version>
         <akka-projection.version>1.1.0</akka-projection.version>
         <akka-persistence-jdbc.version>5.0.0</akka-persistence-jdbc.version>

--- a/docs-source/docs/modules/microservices-tutorial/examples/shopping-cart-service-java/src/main/java/shopping/cart/Main.java
+++ b/docs-source/docs/modules/microservices-tutorial/examples/shopping-cart-service-java/src/main/java/shopping/cart/Main.java
@@ -37,9 +37,6 @@ public class Main {
 
   public static void init(ActorSystem<Void> system, ShoppingOrderService orderService) {
     // end::SendOrderProjection[]
-    AkkaManagement.get(system).start();
-    ClusterBootstrap.get(system).start();
-
     ShoppingCart.init(system);
 
     ApplicationContext springContext = SpringIntegration.applicationContext(system);

--- a/docs-source/docs/modules/microservices-tutorial/examples/shopping-cart-service-scala/build.sbt
+++ b/docs-source/docs/modules/microservices-tutorial/examples/shopping-cart-service-scala/build.sbt
@@ -27,7 +27,7 @@ Global / cancelable := false // ctrl-c
 
 val AkkaVersion = "2.6.13"
 val AkkaHttpVersion = "10.2.3"
-val AkkaManagementVersion = "1.0.9"
+val AkkaManagementVersion = "1.0.9+50-1e0cee33"
 val AkkaPersistenceJdbcVersion = "5.0.0"
 val AlpakkaKafkaVersion = "2.0.6"
 val AkkaProjectionVersion = "1.1.0"

--- a/docs-source/docs/modules/microservices-tutorial/examples/shopping-cart-service-scala/build.sbt
+++ b/docs-source/docs/modules/microservices-tutorial/examples/shopping-cart-service-scala/build.sbt
@@ -27,7 +27,7 @@ Global / cancelable := false // ctrl-c
 
 val AkkaVersion = "2.6.13"
 val AkkaHttpVersion = "10.2.3"
-val AkkaManagementVersion = "1.0.9+50-1e0cee33"
+val AkkaManagementVersion = "1.0.10"
 val AkkaPersistenceJdbcVersion = "5.0.0"
 val AlpakkaKafkaVersion = "2.0.6"
 val AkkaProjectionVersion = "1.1.0"

--- a/docs-source/docs/modules/microservices-tutorial/examples/shopping-cart-service-scala/src/main/resources/cluster.conf
+++ b/docs-source/docs/modules/microservices-tutorial/examples/shopping-cart-service-scala/src/main/resources/cluster.conf
@@ -15,8 +15,9 @@ akka {
     }
   }
 }
+
 # Start the ClusterBootstrap extension for cluster formation
-akka.extensions = ["akka.management.cluster.bootstrap.ClusterBootstrap"]
+akka.extensions += "akka.management.cluster.bootstrap.ClusterBootstrap"
 
 akka.management {
   http {

--- a/docs-source/docs/modules/microservices-tutorial/examples/shopping-cart-service-scala/src/main/resources/cluster.conf
+++ b/docs-source/docs/modules/microservices-tutorial/examples/shopping-cart-service-scala/src/main/resources/cluster.conf
@@ -15,6 +15,8 @@ akka {
     }
   }
 }
+# Start the ClusterBootstrap extension for cluster formation
+akka.extensions = ["akka.management.cluster.bootstrap.ClusterBootstrap"]
 
 akka.management {
   http {

--- a/docs-source/docs/modules/microservices-tutorial/examples/shopping-cart-service-scala/src/main/resources/local-shared.conf
+++ b/docs-source/docs/modules/microservices-tutorial/examples/shopping-cart-service-scala/src/main/resources/local-shared.conf
@@ -2,6 +2,9 @@ shopping-cart-service.grpc.interface = "127.0.0.1"
 akka.remote.artery.canonical.hostname = "127.0.0.1"
 akka.management.http.hostname = "127.0.0.1"
 
+# Start the ClusterBootstrap extension for cluster formation
+akka.extensions = ["akka.management.cluster.bootstrap.ClusterBootstrap"]
+
 akka.management.cluster.bootstrap.contact-point-discovery {
   service-name = "shopping-cart-service"
   discovery-method = config

--- a/docs-source/docs/modules/microservices-tutorial/examples/shopping-cart-service-scala/src/main/resources/local-shared.conf
+++ b/docs-source/docs/modules/microservices-tutorial/examples/shopping-cart-service-scala/src/main/resources/local-shared.conf
@@ -2,9 +2,6 @@ shopping-cart-service.grpc.interface = "127.0.0.1"
 akka.remote.artery.canonical.hostname = "127.0.0.1"
 akka.management.http.hostname = "127.0.0.1"
 
-# Start the ClusterBootstrap extension for cluster formation
-akka.extensions = ["akka.management.cluster.bootstrap.ClusterBootstrap"]
-
 akka.management.cluster.bootstrap.contact-point-discovery {
   service-name = "shopping-cart-service"
   discovery-method = config

--- a/docs-source/docs/modules/microservices-tutorial/examples/shopping-cart-service-scala/src/main/scala/shopping/cart/Main.scala
+++ b/docs-source/docs/modules/microservices-tutorial/examples/shopping-cart-service-scala/src/main/scala/shopping/cart/Main.scala
@@ -1,16 +1,16 @@
 package shopping.cart
 
-import akka.actor.typed.scaladsl.Behaviors
-import akka.actor.typed.ActorSystem
-import akka.management.cluster.bootstrap.ClusterBootstrap
-import akka.management.scaladsl.AkkaManagement
-import org.slf4j.LoggerFactory
 import scala.util.control.NonFatal
+
+import akka.actor.typed.ActorSystem
+import akka.actor.typed.scaladsl.Behaviors
+import org.slf4j.LoggerFactory
 import shopping.cart.repository.ItemPopularityRepositoryImpl
 import shopping.cart.repository.ScalikeJdbcSetup
 // tag::SendOrderProjection[]
-import shopping.order.proto.{ ShoppingOrderService, ShoppingOrderServiceClient }
 import akka.grpc.GrpcClientSettings
+import shopping.order.proto.ShoppingOrderService
+import shopping.order.proto.ShoppingOrderServiceClient
 
 object Main {
 
@@ -32,9 +32,6 @@ object Main {
   def init(system: ActorSystem[_], orderService: ShoppingOrderService): Unit = {
     // end::SendOrderProjection[]
     ScalikeJdbcSetup.init(system)
-
-    AkkaManagement(system).start()
-    ClusterBootstrap(system).start()
 
     ShoppingCart.init(system)
 

--- a/docs-source/docs/modules/microservices-tutorial/examples/shopping-cart-service-scala/src/test/resources/integration-test.conf
+++ b/docs-source/docs/modules/microservices-tutorial/examples/shopping-cart-service-scala/src/test/resources/integration-test.conf
@@ -30,6 +30,9 @@ shopping-cart-service.grpc {
 // akka.management.http.port = set by test per fixture
 // akka.discovery.config.services."shoppingcartservice".endpoints = set by test
 
+# Start the ClusterBootstrap extension for cluster formation
+akka.extensions = ["akka.management.cluster.bootstrap.ClusterBootstrap"]
+
 # don't self-join until all 3 have been started and probed sucessfully
 akka.management.cluster.bootstrap.contact-point-discovery {
   required-contact-point-nr = 3

--- a/docs-source/docs/modules/microservices-tutorial/examples/shopping-cart-service-scala/src/test/resources/integration-test.conf
+++ b/docs-source/docs/modules/microservices-tutorial/examples/shopping-cart-service-scala/src/test/resources/integration-test.conf
@@ -30,9 +30,6 @@ shopping-cart-service.grpc {
 // akka.management.http.port = set by test per fixture
 // akka.discovery.config.services."shoppingcartservice".endpoints = set by test
 
-# Start the ClusterBootstrap extension for cluster formation
-akka.extensions = ["akka.management.cluster.bootstrap.ClusterBootstrap"]
-
 # don't self-join until all 3 have been started and probed sucessfully
 akka.management.cluster.bootstrap.contact-point-discovery {
   required-contact-point-nr = 3

--- a/docs-source/docs/modules/microservices-tutorial/examples/shopping-cart-service-scala/src/test/resources/item-popularity-integration-test.conf
+++ b/docs-source/docs/modules/microservices-tutorial/examples/shopping-cart-service-scala/src/test/resources/item-popularity-integration-test.conf
@@ -1,4 +1,4 @@
-include "application"
+include "local1"
 include "persistence-test"
 
 akka.remote.artery.canonical {

--- a/docs-source/docs/modules/microservices-tutorial/examples/shopping-cart-service-scala/src/test/scala/shopping/cart/ItemPopularityIntegrationSpec.scala
+++ b/docs-source/docs/modules/microservices-tutorial/examples/shopping-cart-service-scala/src/test/scala/shopping/cart/ItemPopularityIntegrationSpec.scala
@@ -53,7 +53,7 @@ class ItemPopularityIntegrationSpec
 
   "Item popularity projection" should {
     "init and join Cluster" in {
-      Cluster(system).manager ! Join(Cluster(system).selfMember.address)
+//      Cluster(system).manager ! Join(Cluster(system).selfMember.address)
 
       // let the node join and become Up
       eventually {

--- a/docs-source/docs/modules/microservices-tutorial/examples/shopping-order-service-java/pom.xml
+++ b/docs-source/docs/modules/microservices-tutorial/examples/shopping-order-service-java/pom.xml
@@ -20,7 +20,7 @@
         <scala.binary.version>2.13</scala.binary.version>
         <akka.version>2.6.13</akka.version>
         <akka-http.version>10.2.2</akka-http.version>
-        <akka-management.version>1.0.9</akka-management.version>
+        <akka-management.version>1.0.10</akka-management.version>
         <alpakka-kafka.version>2.0.6</alpakka-kafka.version>
         <akka-projection.version>1.1.0</akka-projection.version>
         <akka-persistence-jdbc.version>5.0.0</akka-persistence-jdbc.version>

--- a/docs-source/docs/modules/microservices-tutorial/examples/shopping-order-service-java/src/main/java/shopping/order/Main.java
+++ b/docs-source/docs/modules/microservices-tutorial/examples/shopping-order-service-java/src/main/java/shopping/order/Main.java
@@ -24,9 +24,6 @@ public class Main {
   }
 
   public static void init(ActorSystem<Void> system) {
-    AkkaManagement.get(system).start();
-    ClusterBootstrap.get(system).start();
-
     Config config = system.settings().config();
     String grpcInterface = config.getString("shopping-order-service.grpc.interface");
     int grpcPort = config.getInt("shopping-order-service.grpc.port");

--- a/docs-source/docs/modules/microservices-tutorial/examples/shopping-order-service-scala/build.sbt
+++ b/docs-source/docs/modules/microservices-tutorial/examples/shopping-order-service-scala/build.sbt
@@ -27,7 +27,7 @@ Global / cancelable := false // ctrl-c
 
 val AkkaVersion = "2.6.13"
 val AkkaHttpVersion = "10.2.3"
-val AkkaManagementVersion = "1.0.9"
+val AkkaManagementVersion = "1.0.10"
 val AkkaPersistenceJdbcVersion = "5.0.0"
 val AlpakkaKafkaVersion = "2.0.6"
 val AkkaProjectionVersion = "1.1.0"

--- a/docs-source/docs/modules/microservices-tutorial/examples/shopping-order-service-scala/src/main/scala/shopping/order/Main.scala
+++ b/docs-source/docs/modules/microservices-tutorial/examples/shopping-order-service-scala/src/main/scala/shopping/order/Main.scala
@@ -23,9 +23,6 @@ object Main {
   }
 
   def init(system: ActorSystem[_]): Unit = {
-    AkkaManagement(system).start()
-    ClusterBootstrap(system).start()
-
     val grpcInterface =
       system.settings.config.getString("shopping-order-service.grpc.interface")
     val grpcPort =

--- a/docs-source/docs/modules/microservices-tutorial/pages/grpc-service.adoc
+++ b/docs-source/docs/modules/microservices-tutorial/pages/grpc-service.adoc
@@ -139,8 +139,7 @@ include::example$01-shopping-cart-service-scala/src/main/scala/shopping/cart/Mai
 ----
 
 <1> Start an `ActorSystem` with the `Main` actor `Behavior`.
-<2> Initialization of Akka Management that is used for forming the Akka Cluster.
-<3> Initialize the gRPC server. This is the code you should add to the existing `Main`.
+<2> Initialize the gRPC server. This is the code you should add to the existing `Main`.
 
 The `grpc.port` configuration is defined in `local1.conf`, which is included in the generated template project.
 


### PR DESCRIPTION
(edit: this Pr differs from #624 in that this PR _only_ replaces the start of Bootstrap and Management from code to settings)

------------
refs https://github.com/akka/akka-management/issues/850

This needs Akka Management 1.0.10. With a couple of ✅ I'll rollout the copies into all variants of code. 


I've pushed two variants. The variants differ on where the setting is put. In both variants, the code is removed.

1. In variant [`35f7b4b` (#597)](https://github.com/akka/akka-platform-guide/pull/597/commits/35f7b4b1c83380ecbb77171ed0ba4c4b132efdeb) I'm adding the new config settings on the edge (`local-shared.conf` and `integration-test.conf`) next to the configuration of `...cluster.bootstrap.contact-point-discovery` for each running environment.
2. In variant [`87a7e7e` (#597)](https://github.com/akka/akka-platform-guide/pull/597/commits/87a7e7e0f3105874fa99fcb0292879b43166b404), OTOH, I'm adding the new config in `cluster.conf`. As a consequence, some integration tests are affected. For example, the code of `ItemPopularityIntegrationSpec` is simplified but the settings to run the test are now more bloated.

I'm leaning towards option `2.` because even simpler integration tests should `include "local1"` instead of `include "application"`. An integration test needs minimum info regarding the context where it run and `"local1"` provides that. It also feels more natural to enable the cluster bootstrap and akka management just next to the place we're setting the akka management port.



I tried to craft the commits carefully and I recommend reviewing each commit separately:

1. VARIANT 1: "Initial changes: prefer config-based over code for bootstrap starting"
2. VARIANT 2: "Alternate approach: cluster bootstrap is always available"
3. "Append, don't override"
4. "Docs: management and bootstrap via settings" --> fix docs and related code
5. "Step 1: remove programmatic starting of management and bootstrap" --> start replicating the code changes.

This PR is blocked until we decide which variant we prefer. then, I'll add the last commit to add config-based cluster bootstrapping in all code bases.

