### PR TITLE
Update create_user_tables.sql

### DIFF
--- a/docs-source/docs/modules/microservices-tutorial/examples/04-shopping-cart-service-java/ddl-scripts/create_user_tables.sql
+++ b/docs-source/docs/modules/microservices-tutorial/examples/04-shopping-cart-service-java/ddl-scripts/create_user_tables.sql
@@ -1,5 +1,4 @@
 CREATE TABLE IF NOT EXISTS public.item_popularity (
     itemid VARCHAR(255) NOT NULL,
-    version BIGINT NOT NULL,
     count BIGINT NOT NULL,
     PRIMARY KEY (itemid));


### PR DESCRIPTION
We do not use "version" field in ItemPopularity Projection. It case an server Error because it can't be null

<!--
  Are there any relevant issues / PRs / mailing lists discussions?
  Please reference them here - but don't use `fixes` notation.
-->
References #xxxx
