### PR TITLE
30 items is enough

### DIFF
--- a/docs-source/docs/modules/microservices-tutorial/examples/04-shopping-cart-service-java/src/test/java/shopping/cart/ItemPopularityIntegrationTest.java
+++ b/docs-source/docs/modules/microservices-tutorial/examples/04-shopping-cart-service-java/src/test/java/shopping/cart/ItemPopularityIntegrationTest.java
@@ -117,7 +117,7 @@ public class ItemPopularityIntegrationTest {
     ClusterSharding sharding = ClusterSharding.get(system);
 
     final String item = "concurrent-item";
-    int cartCount = 100;
+    int cartCount = 30;
     int itemCount = 1;
     final Duration timeout = Duration.ofSeconds(30);
 
@@ -136,7 +136,7 @@ public class ItemPopularityIntegrationTest {
           return null;
         });
 
-    // ... when 99 concurrent carts add `item1`...
+    // ... when 29 concurrent carts add `item1`...
     for (int i = 1; i < cartCount; i++) {
       sharding
           .entityRefFor(ShoppingCart.ENTITY_KEY, "concurrent-cart" + i)
@@ -144,7 +144,7 @@ public class ItemPopularityIntegrationTest {
               replyTo -> new ShoppingCart.AddItem(item, itemCount, replyTo), timeout);
     }
 
-    // ... then the popularity count is 100
+    // ... then the popularity count is 30
     probe.awaitAssert(
         timeout,
         () -> {

--- a/docs-source/docs/modules/microservices-tutorial/examples/05-shopping-cart-service-java/src/test/java/shopping/cart/ItemPopularityIntegrationTest.java
+++ b/docs-source/docs/modules/microservices-tutorial/examples/05-shopping-cart-service-java/src/test/java/shopping/cart/ItemPopularityIntegrationTest.java
@@ -117,7 +117,7 @@ public class ItemPopularityIntegrationTest {
     ClusterSharding sharding = ClusterSharding.get(system);
 
     final String item = "concurrent-item";
-    int cartCount = 100;
+    int cartCount = 30;
     int itemCount = 1;
     final Duration timeout = Duration.ofSeconds(30);
 
@@ -136,7 +136,7 @@ public class ItemPopularityIntegrationTest {
           return null;
         });
 
-    // ... when 99 concurrent carts add `item1`...
+    // ... when 29 concurrent carts add `item1`...
     for (int i = 1; i < cartCount; i++) {
       sharding
           .entityRefFor(ShoppingCart.ENTITY_KEY, "concurrent-cart" + i)
@@ -144,7 +144,7 @@ public class ItemPopularityIntegrationTest {
               replyTo -> new ShoppingCart.AddItem(item, itemCount, replyTo), timeout);
     }
 
-    // ... then the popularity count is 100
+    // ... then the popularity count is 30
     probe.awaitAssert(
         timeout,
         () -> {

--- a/docs-source/docs/modules/microservices-tutorial/examples/shopping-cart-service-java/src/test/java/shopping/cart/ItemPopularityIntegrationTest.java
+++ b/docs-source/docs/modules/microservices-tutorial/examples/shopping-cart-service-java/src/test/java/shopping/cart/ItemPopularityIntegrationTest.java
@@ -117,7 +117,7 @@ public class ItemPopularityIntegrationTest {
     ClusterSharding sharding = ClusterSharding.get(system);
 
     final String item = "concurrent-item";
-    int cartCount = 100;
+    int cartCount = 30;
     int itemCount = 1;
     final Duration timeout = Duration.ofSeconds(30);
 
@@ -136,7 +136,7 @@ public class ItemPopularityIntegrationTest {
           return null;
         });
 
-    // ... when 99 concurrent carts add `item1`...
+    // ... when 29 concurrent carts add `item1`...
     for (int i = 1; i < cartCount; i++) {
       sharding
           .entityRefFor(ShoppingCart.ENTITY_KEY, "concurrent-cart" + i)
@@ -144,7 +144,7 @@ public class ItemPopularityIntegrationTest {
               replyTo -> new ShoppingCart.AddItem(item, itemCount, replyTo), timeout);
     }
 
-    // ... then the popularity count is 100
+    // ... then the popularity count is 30
     probe.awaitAssert(
         timeout,
         () -> {


### PR DESCRIPTION
This test causes DB collisions and it. therefore, slow and nondeterministic. 

I've seen it fail because it can't complete in the allocated time. 30 items instead of 100 are more than enough to guarantee OptimisticLocking is properly configured.