### PR TITLE
Improve CI reliability

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -48,7 +48,7 @@ jobs:
     name: Compile and Test Part 1 (Java)
     runs-on: ubuntu-18.04
     steps:
-      <<: &java_build
+      <<: *java_build
 
       - name: "Shopping analytics service (Java)"
         run: scripts/mvn-test.sh docs-source/docs/modules/microservices-tutorial/examples/shopping-analytics-service-java

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -47,8 +47,7 @@ jobs:
   java-compile-and-test-part1:
     name: Compile and Test Part 1 (Java)
     runs-on: ubuntu-18.04
-    steps:
-      <<: *java_build
+    steps: *java_build
 
       - name: "Shopping analytics service (Java)"
         run: scripts/mvn-test.sh docs-source/docs/modules/microservices-tutorial/examples/shopping-analytics-service-java

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -24,7 +24,7 @@ jobs:
           git diff --exit-code --color || { echo "[error] Found modified file that was expected to be identical. Run scripts/copy-identical-files.sh"; false; }
 
   java-compile-and-test-part1:
-    name: Compile and Test (Java)
+    name: Compile and Test Part 1 (Java)
     runs-on: ubuntu-18.04
     steps:
       - name: Checkout
@@ -78,7 +78,7 @@ jobs:
         run: scripts/mvn-test.sh docs-source/docs/modules/microservices-tutorial/examples/04-shopping-cart-service-java
 
   java-compile-and-test-part2:
-    name: Compile and Test (Java)
+    name: Compile and Test Part 2 (Java)
     runs-on: ubuntu-18.04
     steps:
       - name: Checkout
@@ -108,7 +108,7 @@ jobs:
         run: scripts/mvn-test.sh docs-source/docs/modules/how-to/examples/shopping-cart-service-cassandra-java
 
   scala-compile-and-test-part1:
-    name: Compile and Test (Scala)
+    name: Compile and Test Part 1 (Scala)
     runs-on: ubuntu-18.04
     steps:
       - name: Checkout
@@ -159,7 +159,7 @@ jobs:
         run: scripts/sbt-test.sh docs-source/docs/modules/microservices-tutorial/examples/04-shopping-cart-service-scala
 
   scala-compile-and-test-part2:
-    name: Compile and Test (Scala)
+    name: Compile and Test Part 2 (Scala)
     runs-on: ubuntu-18.04
     steps:
       - name: Checkout

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -4,6 +4,27 @@ on:
   push:
     # branches: [ main ]
 
+java_build: &java_build
+  - name: Checkout
+    uses: actions/checkout@v2
+
+  - name: Checkout GitHub merge
+    if: github.event.pull_request
+    run: |-
+      git fetch origin pull/${{ github.event.pull_request.number }}/merge:scratch
+      git checkout scratch
+
+  - name: Set up JDK 11
+    uses: olafurpg/setup-scala@v10
+    with:
+      java-version: adopt@1.11.0-9
+
+  - uses: actions/cache@v2.1.3
+    with:
+      path: ~/.m2/repository
+      key: maven-repo-${{ hashFiles('**/pom.xml') }}
+      restore-keys: maven-repo-
+
 jobs:
   copy-identical-files:
     name: Verify identical files are correct
@@ -27,25 +48,7 @@ jobs:
     name: Compile and Test Part 1 (Java)
     runs-on: ubuntu-18.04
     steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-
-      - name: Checkout GitHub merge
-        if: github.event.pull_request
-        run: |-
-          git fetch origin pull/${{ github.event.pull_request.number }}/merge:scratch
-          git checkout scratch
-
-      - name: Set up JDK 11
-        uses: olafurpg/setup-scala@v10
-        with:
-          java-version: adopt@1.11.0-9
-
-      - uses: actions/cache@v2.1.3
-        with:
-          path: ~/.m2/repository
-          key: maven-repo-${{ hashFiles('**/pom.xml') }}
-          restore-keys: maven-repo-
+      <<: &java_build
 
       - name: "Shopping analytics service (Java)"
         run: scripts/mvn-test.sh docs-source/docs/modules/microservices-tutorial/examples/shopping-analytics-service-java

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -4,27 +4,6 @@ on:
   push:
     # branches: [ main ]
 
-java_build: &java_build
-  - name: Checkout
-    uses: actions/checkout@v2
-
-  - name: Checkout GitHub merge
-    if: github.event.pull_request
-    run: |-
-      git fetch origin pull/${{ github.event.pull_request.number }}/merge:scratch
-      git checkout scratch
-
-  - name: Set up JDK 11
-    uses: olafurpg/setup-scala@v10
-    with:
-      java-version: adopt@1.11.0-9
-
-  - uses: actions/cache@v2.1.3
-    with:
-      path: ~/.m2/repository
-      key: maven-repo-${{ hashFiles('**/pom.xml') }}
-      restore-keys: maven-repo-
-
 jobs:
   copy-identical-files:
     name: Verify identical files are correct
@@ -47,7 +26,26 @@ jobs:
   java-compile-and-test-part1:
     name: Compile and Test Part 1 (Java)
     runs-on: ubuntu-18.04
-    steps: *java_build
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Checkout GitHub merge
+        if: github.event.pull_request
+        run: |-
+          git fetch origin pull/${{ github.event.pull_request.number }}/merge:scratch
+          git checkout scratch
+
+      - name: Set up JDK 11
+        uses: olafurpg/setup-scala@v10
+        with:
+          java-version: adopt@1.11.0-9
+
+      - uses: actions/cache@v2.1.3
+        with:
+          path: ~/.m2/repository
+          key: maven-repo-${{ hashFiles('**/pom.xml') }}
+          restore-keys: maven-repo-
 
       - name: "Shopping analytics service (Java)"
         run: scripts/mvn-test.sh docs-source/docs/modules/microservices-tutorial/examples/shopping-analytics-service-java

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,8 +1,8 @@
 name: CI
 on:
-  # pull_request:
+  pull_request:
   push:
-    # branches: [ main ]
+    branches: [ main ]
 
 jobs:
   copy-identical-files:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -23,7 +23,7 @@ jobs:
           scripts/copy-identical-files.sh
           git diff --exit-code --color || { echo "[error] Found modified file that was expected to be identical. Run scripts/copy-identical-files.sh"; false; }
 
-  java-compile-and-test:
+  java-compile-and-test-part1:
     name: Compile and Test (Java)
     runs-on: ubuntu-18.04
     steps:
@@ -47,43 +47,67 @@ jobs:
           key: maven-repo-${{ hashFiles('**/pom.xml') }}
           restore-keys: maven-repo-
 
-      # - name: "Shopping analytics service (Java)"
-      #   run: scripts/mvn-test.sh docs-source/docs/modules/microservices-tutorial/examples/shopping-analytics-service-java
+      - name: "Shopping analytics service (Java)"
+        run: scripts/mvn-test.sh docs-source/docs/modules/microservices-tutorial/examples/shopping-analytics-service-java
 
-      # - name: "Shopping cart service (Java)"
-      #   run: scripts/mvn-test.sh docs-source/docs/modules/microservices-tutorial/examples/shopping-cart-service-java
+      - name: "Shopping cart service (Java)"
+        run: scripts/mvn-test.sh docs-source/docs/modules/microservices-tutorial/examples/shopping-cart-service-java
 
-      # - name: "Shopping order service (Java)"
-      #   run: scripts/mvn-test.sh docs-source/docs/modules/microservices-tutorial/examples/shopping-order-service-java
+      - name: "Shopping order service (Java)"
+        run: scripts/mvn-test.sh docs-source/docs/modules/microservices-tutorial/examples/shopping-order-service-java
 
-      # - name: "00 Shopping analytics service (Java)"
-      #   run: scripts/mvn-test.sh docs-source/docs/modules/microservices-tutorial/examples/00-shopping-analytics-service-java
+      - name: "00 Shopping analytics service (Java)"
+        run: scripts/mvn-test.sh docs-source/docs/modules/microservices-tutorial/examples/00-shopping-analytics-service-java
 
-      # - name: "00 Shopping cart service (Java)"
-      #   run: scripts/mvn-test.sh docs-source/docs/modules/microservices-tutorial/examples/00-shopping-cart-service-java
+      - name: "00 Shopping cart service (Java)"
+        run: scripts/mvn-test.sh docs-source/docs/modules/microservices-tutorial/examples/00-shopping-cart-service-java
 
-      # - name: "00 Shopping order service (Java)"
-      #   run: scripts/mvn-test.sh docs-source/docs/modules/microservices-tutorial/examples/00-shopping-order-service-java
+      - name: "00 Shopping order service (Java)"
+        run: scripts/mvn-test.sh docs-source/docs/modules/microservices-tutorial/examples/00-shopping-order-service-java
 
-      # - name: "01 Shopping cart service (Java)"
-      #   run: scripts/mvn-test.sh docs-source/docs/modules/microservices-tutorial/examples/01-shopping-cart-service-java
+      - name: "01 Shopping cart service (Java)"
+        run: scripts/mvn-test.sh docs-source/docs/modules/microservices-tutorial/examples/01-shopping-cart-service-java
 
-      # - name: "02 Shopping cart service (Java)"
-      #   run: scripts/mvn-test.sh docs-source/docs/modules/microservices-tutorial/examples/02-shopping-cart-service-java
+      - name: "02 Shopping cart service (Java)"
+        run: scripts/mvn-test.sh docs-source/docs/modules/microservices-tutorial/examples/02-shopping-cart-service-java
 
-      # - name: "03 Shopping cart service (Java)"
-      #   run: scripts/mvn-test.sh docs-source/docs/modules/microservices-tutorial/examples/03-shopping-cart-service-java
+      - name: "03 Shopping cart service (Java)"
+        run: scripts/mvn-test.sh docs-source/docs/modules/microservices-tutorial/examples/03-shopping-cart-service-java
 
-      # - name: "04 Shopping cart service (Java)"
-      #   run: scripts/mvn-test.sh docs-source/docs/modules/microservices-tutorial/examples/04-shopping-cart-service-java
+      - name: "04 Shopping cart service (Java)"
+        run: scripts/mvn-test.sh docs-source/docs/modules/microservices-tutorial/examples/04-shopping-cart-service-java
+
+  java-compile-and-test-part2:
+    name: Compile and Test (Java)
+    runs-on: ubuntu-18.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Checkout GitHub merge
+        if: github.event.pull_request
+        run: |-
+          git fetch origin pull/${{ github.event.pull_request.number }}/merge:scratch
+          git checkout scratch
+
+      - name: Set up JDK 11
+        uses: olafurpg/setup-scala@v10
+        with:
+          java-version: adopt@1.11.0-9
+
+      - uses: actions/cache@v2.1.3
+        with:
+          path: ~/.m2/repository
+          key: maven-repo-${{ hashFiles('**/pom.xml') }}
+          restore-keys: maven-repo-
 
       - name: "05 Shopping cart service (Java)"
         run: scripts/mvn-test.sh docs-source/docs/modules/microservices-tutorial/examples/05-shopping-cart-service-java
 
-      # - name: "Howto Cassandra code (Java)"
-      #   run: scripts/mvn-test.sh docs-source/docs/modules/how-to/examples/shopping-cart-service-cassandra-java
+      - name: "Howto Cassandra code (Java)"
+        run: scripts/mvn-test.sh docs-source/docs/modules/how-to/examples/shopping-cart-service-cassandra-java
 
-  scala-compile-and-test:
+  scala-compile-and-test-part1:
     name: Compile and Test (Scala)
     runs-on: ubuntu-18.04
     steps:
@@ -104,45 +128,66 @@ jobs:
       - name: Cache Coursier cache
         uses: coursier/cache-action@v5
 
-      # - name: "Shopping analytics service (Scala)"
-      #   run: scripts/sbt-test.sh docs-source/docs/modules/microservices-tutorial/examples/shopping-analytics-service-scala
+      - name: "Shopping analytics service (Scala)"
+        run: scripts/sbt-test.sh docs-source/docs/modules/microservices-tutorial/examples/shopping-analytics-service-scala
 
-      # - name: "Shopping cart service (Scala)"
-      #   run: scripts/sbt-test.sh docs-source/docs/modules/microservices-tutorial/examples/shopping-cart-service-scala
+      - name: "Shopping cart service (Scala)"
+        run: scripts/sbt-test.sh docs-source/docs/modules/microservices-tutorial/examples/shopping-cart-service-scala
 
-      # - name: "Shopping order service (Scala)"
-      #   run: scripts/sbt-test.sh docs-source/docs/modules/microservices-tutorial/examples/shopping-order-service-scala
+      - name: "Shopping order service (Scala)"
+        run: scripts/sbt-test.sh docs-source/docs/modules/microservices-tutorial/examples/shopping-order-service-scala
 
-      # - name: "00 Shopping analytics service (Scala)"
-      #   run: scripts/sbt-test.sh docs-source/docs/modules/microservices-tutorial/examples/00-shopping-analytics-service-scala
+      - name: "00 Shopping analytics service (Scala)"
+        run: scripts/sbt-test.sh docs-source/docs/modules/microservices-tutorial/examples/00-shopping-analytics-service-scala
 
-      # - name: "00 Shopping cart service (Scala)"
-      #   run: scripts/sbt-test.sh docs-source/docs/modules/microservices-tutorial/examples/00-shopping-cart-service-scala
+      - name: "00 Shopping cart service (Scala)"
+        run: scripts/sbt-test.sh docs-source/docs/modules/microservices-tutorial/examples/00-shopping-cart-service-scala
 
-      # - name: "00 Shopping order service (Scala)"
-      #   run: scripts/sbt-test.sh docs-source/docs/modules/microservices-tutorial/examples/00-shopping-order-service-scala
+      - name: "00 Shopping order service (Scala)"
+        run: scripts/sbt-test.sh docs-source/docs/modules/microservices-tutorial/examples/00-shopping-order-service-scala
 
-      # - name: "01 Shopping cart service (Scala)"
-      #   run: scripts/sbt-test.sh docs-source/docs/modules/microservices-tutorial/examples/01-shopping-cart-service-scala
+      - name: "01 Shopping cart service (Scala)"
+        run: scripts/sbt-test.sh docs-source/docs/modules/microservices-tutorial/examples/01-shopping-cart-service-scala
 
-      # - name: "02 Shopping cart service (Scala)"
-      #   run: scripts/sbt-test.sh docs-source/docs/modules/microservices-tutorial/examples/02-shopping-cart-service-scala
+      - name: "02 Shopping cart service (Scala)"
+        run: scripts/sbt-test.sh docs-source/docs/modules/microservices-tutorial/examples/02-shopping-cart-service-scala
 
-      # - name: "03 Shopping cart service (Scala)"
-      #   run: scripts/sbt-test.sh docs-source/docs/modules/microservices-tutorial/examples/03-shopping-cart-service-scala
+      - name: "03 Shopping cart service (Scala)"
+        run: scripts/sbt-test.sh docs-source/docs/modules/microservices-tutorial/examples/03-shopping-cart-service-scala
 
-      # - name: "04 Shopping cart service (Scala)"
-      #   run: scripts/sbt-test.sh docs-source/docs/modules/microservices-tutorial/examples/04-shopping-cart-service-scala
+      - name: "04 Shopping cart service (Scala)"
+        run: scripts/sbt-test.sh docs-source/docs/modules/microservices-tutorial/examples/04-shopping-cart-service-scala
+
+  scala-compile-and-test-part2:
+    name: Compile and Test (Scala)
+    runs-on: ubuntu-18.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Checkout GitHub merge
+        if: github.event.pull_request
+        run: |-
+          git fetch origin pull/${{ github.event.pull_request.number }}/merge:scratch
+          git checkout scratch
+
+      - name: Set up JDK 11
+        uses: olafurpg/setup-scala@v10
+        with:
+          java-version: adopt@1.11.0-9
+
+      - name: Cache Coursier cache
+        uses: coursier/cache-action@v5
 
       - name: "05 Shopping cart service (Scala)"
         run: scripts/sbt-test.sh docs-source/docs/modules/microservices-tutorial/examples/05-shopping-cart-service-scala
 
-      # - name: "Howto example code"
-      #   run: scripts/sbt-test.sh docs-source/docs/modules/how-to/examples/shopping-cart-service-scala
+      - name: "Howto example code"
+        run: scripts/sbt-test.sh docs-source/docs/modules/how-to/examples/shopping-cart-service-scala
 
-      # - name: "Howto cleanup dependencies"
-      #   run: scripts/sbt-test.sh docs-source/docs/modules/how-to/examples/cleanup-dependencies-project
+      - name: "Howto cleanup dependencies"
+        run: scripts/sbt-test.sh docs-source/docs/modules/how-to/examples/cleanup-dependencies-project
 
-      # - name: "Howto Cassandra code (Scala)"
-      #   run: scripts/sbt-test.sh docs-source/docs/modules/how-to/examples/shopping-cart-service-cassandra-scala
+      - name: "Howto Cassandra code (Scala)"
+        run: scripts/sbt-test.sh docs-source/docs/modules/how-to/examples/shopping-cart-service-cassandra-scala
 

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,8 +1,8 @@
 name: CI
 on:
-  pull_request:
+  # pull_request:
   push:
-    branches: [ main ]
+    # branches: [ main ]
 
 jobs:
   copy-identical-files:
@@ -47,41 +47,41 @@ jobs:
           key: maven-repo-${{ hashFiles('**/pom.xml') }}
           restore-keys: maven-repo-
 
-      - name: "Shopping analytics service (Java)"
-        run: scripts/mvn-test.sh docs-source/docs/modules/microservices-tutorial/examples/shopping-analytics-service-java
+      # - name: "Shopping analytics service (Java)"
+      #   run: scripts/mvn-test.sh docs-source/docs/modules/microservices-tutorial/examples/shopping-analytics-service-java
 
-      - name: "Shopping cart service (Java)"
-        run: scripts/mvn-test.sh docs-source/docs/modules/microservices-tutorial/examples/shopping-cart-service-java
+      # - name: "Shopping cart service (Java)"
+      #   run: scripts/mvn-test.sh docs-source/docs/modules/microservices-tutorial/examples/shopping-cart-service-java
 
-      - name: "Shopping order service (Java)"
-        run: scripts/mvn-test.sh docs-source/docs/modules/microservices-tutorial/examples/shopping-order-service-java
+      # - name: "Shopping order service (Java)"
+      #   run: scripts/mvn-test.sh docs-source/docs/modules/microservices-tutorial/examples/shopping-order-service-java
 
-      - name: "00 Shopping analytics service (Java)"
-        run: scripts/mvn-test.sh docs-source/docs/modules/microservices-tutorial/examples/00-shopping-analytics-service-java
+      # - name: "00 Shopping analytics service (Java)"
+      #   run: scripts/mvn-test.sh docs-source/docs/modules/microservices-tutorial/examples/00-shopping-analytics-service-java
 
-      - name: "00 Shopping cart service (Java)"
-        run: scripts/mvn-test.sh docs-source/docs/modules/microservices-tutorial/examples/00-shopping-cart-service-java
+      # - name: "00 Shopping cart service (Java)"
+      #   run: scripts/mvn-test.sh docs-source/docs/modules/microservices-tutorial/examples/00-shopping-cart-service-java
 
-      - name: "00 Shopping order service (Java)"
-        run: scripts/mvn-test.sh docs-source/docs/modules/microservices-tutorial/examples/00-shopping-order-service-java
+      # - name: "00 Shopping order service (Java)"
+      #   run: scripts/mvn-test.sh docs-source/docs/modules/microservices-tutorial/examples/00-shopping-order-service-java
 
-      - name: "01 Shopping cart service (Java)"
-        run: scripts/mvn-test.sh docs-source/docs/modules/microservices-tutorial/examples/01-shopping-cart-service-java
+      # - name: "01 Shopping cart service (Java)"
+      #   run: scripts/mvn-test.sh docs-source/docs/modules/microservices-tutorial/examples/01-shopping-cart-service-java
 
-      - name: "02 Shopping cart service (Java)"
-        run: scripts/mvn-test.sh docs-source/docs/modules/microservices-tutorial/examples/02-shopping-cart-service-java
+      # - name: "02 Shopping cart service (Java)"
+      #   run: scripts/mvn-test.sh docs-source/docs/modules/microservices-tutorial/examples/02-shopping-cart-service-java
 
-      - name: "03 Shopping cart service (Java)"
-        run: scripts/mvn-test.sh docs-source/docs/modules/microservices-tutorial/examples/03-shopping-cart-service-java
+      # - name: "03 Shopping cart service (Java)"
+      #   run: scripts/mvn-test.sh docs-source/docs/modules/microservices-tutorial/examples/03-shopping-cart-service-java
 
-      - name: "04 Shopping cart service (Java)"
-        run: scripts/mvn-test.sh docs-source/docs/modules/microservices-tutorial/examples/04-shopping-cart-service-java
+      # - name: "04 Shopping cart service (Java)"
+      #   run: scripts/mvn-test.sh docs-source/docs/modules/microservices-tutorial/examples/04-shopping-cart-service-java
 
       - name: "05 Shopping cart service (Java)"
         run: scripts/mvn-test.sh docs-source/docs/modules/microservices-tutorial/examples/05-shopping-cart-service-java
 
-      - name: "Howto Cassandra code (Java)"
-        run: scripts/mvn-test.sh docs-source/docs/modules/how-to/examples/shopping-cart-service-cassandra-java
+      # - name: "Howto Cassandra code (Java)"
+      #   run: scripts/mvn-test.sh docs-source/docs/modules/how-to/examples/shopping-cart-service-cassandra-java
 
   scala-compile-and-test:
     name: Compile and Test (Scala)
@@ -104,45 +104,45 @@ jobs:
       - name: Cache Coursier cache
         uses: coursier/cache-action@v5
 
-      - name: "Shopping analytics service (Scala)"
-        run: scripts/sbt-test.sh docs-source/docs/modules/microservices-tutorial/examples/shopping-analytics-service-scala
+      # - name: "Shopping analytics service (Scala)"
+      #   run: scripts/sbt-test.sh docs-source/docs/modules/microservices-tutorial/examples/shopping-analytics-service-scala
 
-      - name: "Shopping cart service (Scala)"
-        run: scripts/sbt-test.sh docs-source/docs/modules/microservices-tutorial/examples/shopping-cart-service-scala
+      # - name: "Shopping cart service (Scala)"
+      #   run: scripts/sbt-test.sh docs-source/docs/modules/microservices-tutorial/examples/shopping-cart-service-scala
 
-      - name: "Shopping order service (Scala)"
-        run: scripts/sbt-test.sh docs-source/docs/modules/microservices-tutorial/examples/shopping-order-service-scala
+      # - name: "Shopping order service (Scala)"
+      #   run: scripts/sbt-test.sh docs-source/docs/modules/microservices-tutorial/examples/shopping-order-service-scala
 
-      - name: "00 Shopping analytics service (Scala)"
-        run: scripts/sbt-test.sh docs-source/docs/modules/microservices-tutorial/examples/00-shopping-analytics-service-scala
+      # - name: "00 Shopping analytics service (Scala)"
+      #   run: scripts/sbt-test.sh docs-source/docs/modules/microservices-tutorial/examples/00-shopping-analytics-service-scala
 
-      - name: "00 Shopping cart service (Scala)"
-        run: scripts/sbt-test.sh docs-source/docs/modules/microservices-tutorial/examples/00-shopping-cart-service-scala
+      # - name: "00 Shopping cart service (Scala)"
+      #   run: scripts/sbt-test.sh docs-source/docs/modules/microservices-tutorial/examples/00-shopping-cart-service-scala
 
-      - name: "00 Shopping order service (Scala)"
-        run: scripts/sbt-test.sh docs-source/docs/modules/microservices-tutorial/examples/00-shopping-order-service-scala
+      # - name: "00 Shopping order service (Scala)"
+      #   run: scripts/sbt-test.sh docs-source/docs/modules/microservices-tutorial/examples/00-shopping-order-service-scala
 
-      - name: "01 Shopping cart service (Scala)"
-        run: scripts/sbt-test.sh docs-source/docs/modules/microservices-tutorial/examples/01-shopping-cart-service-scala
+      # - name: "01 Shopping cart service (Scala)"
+      #   run: scripts/sbt-test.sh docs-source/docs/modules/microservices-tutorial/examples/01-shopping-cart-service-scala
 
-      - name: "02 Shopping cart service (Scala)"
-        run: scripts/sbt-test.sh docs-source/docs/modules/microservices-tutorial/examples/02-shopping-cart-service-scala
+      # - name: "02 Shopping cart service (Scala)"
+      #   run: scripts/sbt-test.sh docs-source/docs/modules/microservices-tutorial/examples/02-shopping-cart-service-scala
 
-      - name: "03 Shopping cart service (Scala)"
-        run: scripts/sbt-test.sh docs-source/docs/modules/microservices-tutorial/examples/03-shopping-cart-service-scala
+      # - name: "03 Shopping cart service (Scala)"
+      #   run: scripts/sbt-test.sh docs-source/docs/modules/microservices-tutorial/examples/03-shopping-cart-service-scala
 
-      - name: "04 Shopping cart service (Scala)"
-        run: scripts/sbt-test.sh docs-source/docs/modules/microservices-tutorial/examples/04-shopping-cart-service-scala
+      # - name: "04 Shopping cart service (Scala)"
+      #   run: scripts/sbt-test.sh docs-source/docs/modules/microservices-tutorial/examples/04-shopping-cart-service-scala
 
       - name: "05 Shopping cart service (Scala)"
         run: scripts/sbt-test.sh docs-source/docs/modules/microservices-tutorial/examples/05-shopping-cart-service-scala
 
-      - name: "Howto example code"
-        run: scripts/sbt-test.sh docs-source/docs/modules/how-to/examples/shopping-cart-service-scala
+      # - name: "Howto example code"
+      #   run: scripts/sbt-test.sh docs-source/docs/modules/how-to/examples/shopping-cart-service-scala
 
-      - name: "Howto cleanup dependencies"
-        run: scripts/sbt-test.sh docs-source/docs/modules/how-to/examples/cleanup-dependencies-project
+      # - name: "Howto cleanup dependencies"
+      #   run: scripts/sbt-test.sh docs-source/docs/modules/how-to/examples/cleanup-dependencies-project
 
-      - name: "Howto Cassandra code (Scala)"
-        run: scripts/sbt-test.sh docs-source/docs/modules/how-to/examples/shopping-cart-service-cassandra-scala
+      # - name: "Howto Cassandra code (Scala)"
+      #   run: scripts/sbt-test.sh docs-source/docs/modules/how-to/examples/shopping-cart-service-cassandra-scala
 

--- a/docs-source/docs/modules/microservices-tutorial/examples/05-shopping-cart-service-scala/src/test/scala/shopping/cart/IntegrationSpec.scala
+++ b/docs-source/docs/modules/microservices-tutorial/examples/05-shopping-cart-service-scala/src/test/scala/shopping/cart/IntegrationSpec.scala
@@ -199,9 +199,8 @@ class IntegrationSpec
       updatedCart1.items.head.quantity should ===(42)
 
       // first may take longer time
-      val published1 = eventually(PatienceConfiguration.Timeout(30.seconds)) {
-        kafkaTopicProbe.expectMessageType[proto.ItemAdded](2.seconds)
-      }
+      val published1 =
+        kafkaTopicProbe.expectMessageType[proto.ItemAdded](20.seconds)
       published1.cartId should ===("cart-1")
       published1.itemId should ===("foo")
       published1.quantity should ===(42)

--- a/docs-source/docs/modules/microservices-tutorial/examples/05-shopping-cart-service-scala/src/test/scala/shopping/cart/IntegrationSpec.scala
+++ b/docs-source/docs/modules/microservices-tutorial/examples/05-shopping-cart-service-scala/src/test/scala/shopping/cart/IntegrationSpec.scala
@@ -199,8 +199,9 @@ class IntegrationSpec
       updatedCart1.items.head.quantity should ===(42)
 
       // first may take longer time
-      val published1 =
-        kafkaTopicProbe.expectMessageType[proto.ItemAdded](20.seconds)
+      val published1 = eventually(PatienceConfiguration.Timeout(30.seconds)) {
+        kafkaTopicProbe.expectMessageType[proto.ItemAdded](2.seconds)
+      }
       published1.cartId should ===("cart-1")
       published1.itemId should ===("foo")
       published1.quantity should ===(42)


### PR DESCRIPTION
The CI tends to break on `05-shopping-cart-service` (both Scala and Java).
The problem is not reproducible locally, and, testing in isolation works as well.

Here we are splitting the tests into 2 groups, this makes the CI more resilient and might improve CI times ass well with very little copy-pasted configuration.
