### PR TITLE
Wait for Kafka to be ready

### DIFF
--- a/docs-source/docs/modules/microservices-tutorial/examples/00-shopping-analytics-service-java/docker-compose.yml
+++ b/docs-source/docs/modules/microservices-tutorial/examples/00-shopping-analytics-service-java/docker-compose.yml
@@ -18,16 +18,16 @@ services:
       POSTGRES_USER: shopping-cart
       POSTGRES_PASSWORD: shopping-cart
 
-  # See dockerhub for different versions of kafka and zookeeper
-  # https://hub.docker.com/r/wurstmeister/kafka/
-  # https://hub.docker.com/r/wurstmeister/zookeeper/
+# See dockerhub for different versions of kafka and zookeeper
+# https://hub.docker.com/r/wurstmeister/kafka/
+# https://hub.docker.com/r/wurstmeister/zookeeper/
   zookeeper:
-    image: wurstmeister/zookeeper:3.4.6
+    image: zookeeper:3.6.2
     ports:
       - "2181:2181"
 
   kafka:
-    image: wurstmeister/kafka:2.13-2.6.0
+    image: wurstmeister/kafka:2.13-2.7.0
     ports:
       - "9092:9092"
     environment:
@@ -35,3 +35,21 @@ services:
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
+
+  kafka-consumer:
+    image: wurstmeister/kafka:2.13-2.7.0
+    command: bash -c "mkdir -vp /tmp/kafka-logs && /opt/kafka_2.13-2.7.0/bin/kafk-console-consumer.sh --zookeeper zookeeper:2181 --from-beginning --topic-name > /tmp/kafka-logs/topic-name.log"
+    ports:
+      - "9094:9092"
+    links:
+      - zookeeper
+      - kafka
+    volumes:
+      - ./kafka-1-logs:/tmp/kafka-logs
+
+  wait-for-kafka:
+    image: waisbrot/wait
+    links:
+      - kafka
+    environment:
+      - TARGETS=kafka:9092

--- a/docs-source/docs/modules/microservices-tutorial/examples/00-shopping-analytics-service-java/docker-compose.yml
+++ b/docs-source/docs/modules/microservices-tutorial/examples/00-shopping-analytics-service-java/docker-compose.yml
@@ -14,7 +14,7 @@ services:
     ports:
       - 5433:5432
     environment:
-      POSTGRES_DB: shopping-cart-test
+      POSTGRES_DB: shopping-cart
       POSTGRES_USER: shopping-cart
       POSTGRES_PASSWORD: shopping-cart
 

--- a/docs-source/docs/modules/microservices-tutorial/examples/00-shopping-analytics-service-scala/docker-compose.yml
+++ b/docs-source/docs/modules/microservices-tutorial/examples/00-shopping-analytics-service-scala/docker-compose.yml
@@ -14,7 +14,7 @@ services:
     ports:
       - 5433:5432
     environment:
-      POSTGRES_DB: shopping-cart-test
+      POSTGRES_DB: shopping-cart
       POSTGRES_USER: shopping-cart
       POSTGRES_PASSWORD: shopping-cart
 

--- a/docs-source/docs/modules/microservices-tutorial/examples/00-shopping-analytics-service-scala/docker-compose.yml
+++ b/docs-source/docs/modules/microservices-tutorial/examples/00-shopping-analytics-service-scala/docker-compose.yml
@@ -22,12 +22,12 @@ services:
 # https://hub.docker.com/r/wurstmeister/kafka/
 # https://hub.docker.com/r/wurstmeister/zookeeper/
   zookeeper:
-    image: wurstmeister/zookeeper:3.4.6
+    image: zookeeper:3.6.2
     ports:
       - "2181:2181"
 
   kafka:
-    image: wurstmeister/kafka:2.13-2.6.0
+    image: wurstmeister/kafka:2.13-2.7.0
     ports:
       - "9092:9092"
     environment:
@@ -35,3 +35,21 @@ services:
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
+
+  kafka-consumer:
+    image: wurstmeister/kafka:2.13-2.7.0
+    command: bash -c "mkdir -vp /tmp/kafka-logs && /opt/kafka_2.13-2.7.0/bin/kafk-console-consumer.sh --zookeeper zookeeper:2181 --from-beginning --topic-name > /tmp/kafka-logs/topic-name.log"
+    ports:
+      - "9094:9092"
+    links:
+      - zookeeper
+      - kafka
+    volumes:
+      - ./kafka-1-logs:/tmp/kafka-logs
+
+  wait-for-kafka:
+    image: waisbrot/wait
+    links:
+      - kafka
+    environment:
+      - TARGETS=kafka:9092

--- a/docs-source/docs/modules/microservices-tutorial/examples/00-shopping-cart-service-java/docker-compose.yml
+++ b/docs-source/docs/modules/microservices-tutorial/examples/00-shopping-cart-service-java/docker-compose.yml
@@ -14,7 +14,7 @@ services:
     ports:
       - 5433:5432
     environment:
-      POSTGRES_DB: shopping-cart-test
+      POSTGRES_DB: shopping-cart
       POSTGRES_USER: shopping-cart
       POSTGRES_PASSWORD: shopping-cart
 

--- a/docs-source/docs/modules/microservices-tutorial/examples/00-shopping-cart-service-java/docker-compose.yml
+++ b/docs-source/docs/modules/microservices-tutorial/examples/00-shopping-cart-service-java/docker-compose.yml
@@ -14,20 +14,20 @@ services:
     ports:
       - 5433:5432
     environment:
-      POSTGRES_DB: shopping-cart
+      POSTGRES_DB: shopping-cart-test
       POSTGRES_USER: shopping-cart
       POSTGRES_PASSWORD: shopping-cart
 
-  # See dockerhub for different versions of kafka and zookeeper
-  # https://hub.docker.com/r/wurstmeister/kafka/
-  # https://hub.docker.com/r/wurstmeister/zookeeper/
+# See dockerhub for different versions of kafka and zookeeper
+# https://hub.docker.com/r/wurstmeister/kafka/
+# https://hub.docker.com/r/wurstmeister/zookeeper/
   zookeeper:
-    image: wurstmeister/zookeeper:3.4.6
+    image: zookeeper:3.6.2
     ports:
       - "2181:2181"
 
   kafka:
-    image: wurstmeister/kafka:2.13-2.6.0
+    image: wurstmeister/kafka:2.13-2.7.0
     ports:
       - "9092:9092"
     environment:
@@ -35,3 +35,21 @@ services:
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
+
+  kafka-consumer:
+    image: wurstmeister/kafka:2.13-2.7.0
+    command: bash -c "mkdir -vp /tmp/kafka-logs && /opt/kafka_2.13-2.7.0/bin/kafk-console-consumer.sh --zookeeper zookeeper:2181 --from-beginning --topic-name > /tmp/kafka-logs/topic-name.log"
+    ports:
+      - "9094:9092"
+    links:
+      - zookeeper
+      - kafka
+    volumes:
+      - ./kafka-1-logs:/tmp/kafka-logs
+
+  wait-for-kafka:
+    image: waisbrot/wait
+    links:
+      - kafka
+    environment:
+      - TARGETS=kafka:9092

--- a/docs-source/docs/modules/microservices-tutorial/examples/00-shopping-cart-service-scala/docker-compose.yml
+++ b/docs-source/docs/modules/microservices-tutorial/examples/00-shopping-cart-service-scala/docker-compose.yml
@@ -14,7 +14,7 @@ services:
     ports:
       - 5433:5432
     environment:
-      POSTGRES_DB: shopping-cart-test
+      POSTGRES_DB: shopping-cart
       POSTGRES_USER: shopping-cart
       POSTGRES_PASSWORD: shopping-cart
 

--- a/docs-source/docs/modules/microservices-tutorial/examples/00-shopping-cart-service-scala/docker-compose.yml
+++ b/docs-source/docs/modules/microservices-tutorial/examples/00-shopping-cart-service-scala/docker-compose.yml
@@ -22,12 +22,12 @@ services:
 # https://hub.docker.com/r/wurstmeister/kafka/
 # https://hub.docker.com/r/wurstmeister/zookeeper/
   zookeeper:
-    image: wurstmeister/zookeeper:3.4.6
+    image: zookeeper:3.6.2
     ports:
       - "2181:2181"
 
   kafka:
-    image: wurstmeister/kafka:2.13-2.6.0
+    image: wurstmeister/kafka:2.13-2.7.0
     ports:
       - "9092:9092"
     environment:
@@ -35,3 +35,21 @@ services:
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
+
+  kafka-consumer:
+    image: wurstmeister/kafka:2.13-2.7.0
+    command: bash -c "mkdir -vp /tmp/kafka-logs && /opt/kafka_2.13-2.7.0/bin/kafk-console-consumer.sh --zookeeper zookeeper:2181 --from-beginning --topic-name > /tmp/kafka-logs/topic-name.log"
+    ports:
+      - "9094:9092"
+    links:
+      - zookeeper
+      - kafka
+    volumes:
+      - ./kafka-1-logs:/tmp/kafka-logs
+
+  wait-for-kafka:
+    image: waisbrot/wait
+    links:
+      - kafka
+    environment:
+      - TARGETS=kafka:9092

--- a/docs-source/docs/modules/microservices-tutorial/examples/00-shopping-cart-service-scala/src/test/resources/persistence-test.conf
+++ b/docs-source/docs/modules/microservices-tutorial/examples/00-shopping-cart-service-scala/src/test/resources/persistence-test.conf
@@ -1,5 +1,5 @@
 jdbc-connection-settings {
-  url = "jdbc:postgresql://localhost:5433/shopping-cart-test?reWriteBatchedInserts=true"
+  url = "jdbc:postgresql://localhost:5433/shopping-cart?reWriteBatchedInserts=true"
   user = "shopping-cart"
   password = "shopping-cart"
 }

--- a/docs-source/docs/modules/microservices-tutorial/examples/00-shopping-order-service-java/docker-compose.yml
+++ b/docs-source/docs/modules/microservices-tutorial/examples/00-shopping-order-service-java/docker-compose.yml
@@ -18,16 +18,16 @@ services:
       POSTGRES_USER: shopping-cart
       POSTGRES_PASSWORD: shopping-cart
 
-  # See dockerhub for different versions of kafka and zookeeper
-  # https://hub.docker.com/r/wurstmeister/kafka/
-  # https://hub.docker.com/r/wurstmeister/zookeeper/
+# See dockerhub for different versions of kafka and zookeeper
+# https://hub.docker.com/r/wurstmeister/kafka/
+# https://hub.docker.com/r/wurstmeister/zookeeper/
   zookeeper:
-    image: wurstmeister/zookeeper:3.4.6
+    image: zookeeper:3.6.2
     ports:
       - "2181:2181"
 
   kafka:
-    image: wurstmeister/kafka:2.13-2.6.0
+    image: wurstmeister/kafka:2.13-2.7.0
     ports:
       - "9092:9092"
     environment:
@@ -35,3 +35,21 @@ services:
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
+
+  kafka-consumer:
+    image: wurstmeister/kafka:2.13-2.7.0
+    command: bash -c "mkdir -vp /tmp/kafka-logs && /opt/kafka_2.13-2.7.0/bin/kafk-console-consumer.sh --zookeeper zookeeper:2181 --from-beginning --topic-name > /tmp/kafka-logs/topic-name.log"
+    ports:
+      - "9094:9092"
+    links:
+      - zookeeper
+      - kafka
+    volumes:
+      - ./kafka-1-logs:/tmp/kafka-logs
+
+  wait-for-kafka:
+    image: waisbrot/wait
+    links:
+      - kafka
+    environment:
+      - TARGETS=kafka:9092

--- a/docs-source/docs/modules/microservices-tutorial/examples/00-shopping-order-service-java/docker-compose.yml
+++ b/docs-source/docs/modules/microservices-tutorial/examples/00-shopping-order-service-java/docker-compose.yml
@@ -14,7 +14,7 @@ services:
     ports:
       - 5433:5432
     environment:
-      POSTGRES_DB: shopping-cart-test
+      POSTGRES_DB: shopping-cart
       POSTGRES_USER: shopping-cart
       POSTGRES_PASSWORD: shopping-cart
 

--- a/docs-source/docs/modules/microservices-tutorial/examples/00-shopping-order-service-scala/docker-compose.yml
+++ b/docs-source/docs/modules/microservices-tutorial/examples/00-shopping-order-service-scala/docker-compose.yml
@@ -14,7 +14,7 @@ services:
     ports:
       - 5433:5432
     environment:
-      POSTGRES_DB: shopping-cart-test
+      POSTGRES_DB: shopping-cart
       POSTGRES_USER: shopping-cart
       POSTGRES_PASSWORD: shopping-cart
 

--- a/docs-source/docs/modules/microservices-tutorial/examples/00-shopping-order-service-scala/docker-compose.yml
+++ b/docs-source/docs/modules/microservices-tutorial/examples/00-shopping-order-service-scala/docker-compose.yml
@@ -22,12 +22,12 @@ services:
 # https://hub.docker.com/r/wurstmeister/kafka/
 # https://hub.docker.com/r/wurstmeister/zookeeper/
   zookeeper:
-    image: wurstmeister/zookeeper:3.4.6
+    image: zookeeper:3.6.2
     ports:
       - "2181:2181"
 
   kafka:
-    image: wurstmeister/kafka:2.13-2.6.0
+    image: wurstmeister/kafka:2.13-2.7.0
     ports:
       - "9092:9092"
     environment:
@@ -35,3 +35,21 @@ services:
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
+
+  kafka-consumer:
+    image: wurstmeister/kafka:2.13-2.7.0
+    command: bash -c "mkdir -vp /tmp/kafka-logs && /opt/kafka_2.13-2.7.0/bin/kafk-console-consumer.sh --zookeeper zookeeper:2181 --from-beginning --topic-name > /tmp/kafka-logs/topic-name.log"
+    ports:
+      - "9094:9092"
+    links:
+      - zookeeper
+      - kafka
+    volumes:
+      - ./kafka-1-logs:/tmp/kafka-logs
+
+  wait-for-kafka:
+    image: waisbrot/wait
+    links:
+      - kafka
+    environment:
+      - TARGETS=kafka:9092

--- a/docs-source/docs/modules/microservices-tutorial/examples/01-shopping-cart-service-java/docker-compose.yml
+++ b/docs-source/docs/modules/microservices-tutorial/examples/01-shopping-cart-service-java/docker-compose.yml
@@ -14,7 +14,7 @@ services:
     ports:
       - 5433:5432
     environment:
-      POSTGRES_DB: shopping-cart-test
+      POSTGRES_DB: shopping-cart
       POSTGRES_USER: shopping-cart
       POSTGRES_PASSWORD: shopping-cart
 

--- a/docs-source/docs/modules/microservices-tutorial/examples/01-shopping-cart-service-java/docker-compose.yml
+++ b/docs-source/docs/modules/microservices-tutorial/examples/01-shopping-cart-service-java/docker-compose.yml
@@ -14,20 +14,20 @@ services:
     ports:
       - 5433:5432
     environment:
-      POSTGRES_DB: shopping-cart
+      POSTGRES_DB: shopping-cart-test
       POSTGRES_USER: shopping-cart
       POSTGRES_PASSWORD: shopping-cart
 
-  # See dockerhub for different versions of kafka and zookeeper
-  # https://hub.docker.com/r/wurstmeister/kafka/
-  # https://hub.docker.com/r/wurstmeister/zookeeper/
+# See dockerhub for different versions of kafka and zookeeper
+# https://hub.docker.com/r/wurstmeister/kafka/
+# https://hub.docker.com/r/wurstmeister/zookeeper/
   zookeeper:
-    image: wurstmeister/zookeeper:3.4.6
+    image: zookeeper:3.6.2
     ports:
       - "2181:2181"
 
   kafka:
-    image: wurstmeister/kafka:2.13-2.6.0
+    image: wurstmeister/kafka:2.13-2.7.0
     ports:
       - "9092:9092"
     environment:
@@ -35,3 +35,21 @@ services:
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
+
+  kafka-consumer:
+    image: wurstmeister/kafka:2.13-2.7.0
+    command: bash -c "mkdir -vp /tmp/kafka-logs && /opt/kafka_2.13-2.7.0/bin/kafk-console-consumer.sh --zookeeper zookeeper:2181 --from-beginning --topic-name > /tmp/kafka-logs/topic-name.log"
+    ports:
+      - "9094:9092"
+    links:
+      - zookeeper
+      - kafka
+    volumes:
+      - ./kafka-1-logs:/tmp/kafka-logs
+
+  wait-for-kafka:
+    image: waisbrot/wait
+    links:
+      - kafka
+    environment:
+      - TARGETS=kafka:9092

--- a/docs-source/docs/modules/microservices-tutorial/examples/01-shopping-cart-service-scala/docker-compose.yml
+++ b/docs-source/docs/modules/microservices-tutorial/examples/01-shopping-cart-service-scala/docker-compose.yml
@@ -14,7 +14,7 @@ services:
     ports:
       - 5433:5432
     environment:
-      POSTGRES_DB: shopping-cart-test
+      POSTGRES_DB: shopping-cart
       POSTGRES_USER: shopping-cart
       POSTGRES_PASSWORD: shopping-cart
 

--- a/docs-source/docs/modules/microservices-tutorial/examples/01-shopping-cart-service-scala/docker-compose.yml
+++ b/docs-source/docs/modules/microservices-tutorial/examples/01-shopping-cart-service-scala/docker-compose.yml
@@ -22,12 +22,12 @@ services:
 # https://hub.docker.com/r/wurstmeister/kafka/
 # https://hub.docker.com/r/wurstmeister/zookeeper/
   zookeeper:
-    image: wurstmeister/zookeeper:3.4.6
+    image: zookeeper:3.6.2
     ports:
       - "2181:2181"
 
   kafka:
-    image: wurstmeister/kafka:2.13-2.6.0
+    image: wurstmeister/kafka:2.13-2.7.0
     ports:
       - "9092:9092"
     environment:
@@ -35,3 +35,21 @@ services:
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
+
+  kafka-consumer:
+    image: wurstmeister/kafka:2.13-2.7.0
+    command: bash -c "mkdir -vp /tmp/kafka-logs && /opt/kafka_2.13-2.7.0/bin/kafk-console-consumer.sh --zookeeper zookeeper:2181 --from-beginning --topic-name > /tmp/kafka-logs/topic-name.log"
+    ports:
+      - "9094:9092"
+    links:
+      - zookeeper
+      - kafka
+    volumes:
+      - ./kafka-1-logs:/tmp/kafka-logs
+
+  wait-for-kafka:
+    image: waisbrot/wait
+    links:
+      - kafka
+    environment:
+      - TARGETS=kafka:9092

--- a/docs-source/docs/modules/microservices-tutorial/examples/01-shopping-cart-service-scala/src/test/resources/persistence-test.conf
+++ b/docs-source/docs/modules/microservices-tutorial/examples/01-shopping-cart-service-scala/src/test/resources/persistence-test.conf
@@ -1,5 +1,5 @@
 jdbc-connection-settings {
-  url = "jdbc:postgresql://localhost:5433/shopping-cart-test?reWriteBatchedInserts=true"
+  url = "jdbc:postgresql://localhost:5433/shopping-cart?reWriteBatchedInserts=true"
   user = "shopping-cart"
   password = "shopping-cart"
 }

--- a/docs-source/docs/modules/microservices-tutorial/examples/02-shopping-cart-service-java/docker-compose.yml
+++ b/docs-source/docs/modules/microservices-tutorial/examples/02-shopping-cart-service-java/docker-compose.yml
@@ -14,7 +14,7 @@ services:
     ports:
       - 5433:5432
     environment:
-      POSTGRES_DB: shopping-cart-test
+      POSTGRES_DB: shopping-cart
       POSTGRES_USER: shopping-cart
       POSTGRES_PASSWORD: shopping-cart
 

--- a/docs-source/docs/modules/microservices-tutorial/examples/02-shopping-cart-service-java/docker-compose.yml
+++ b/docs-source/docs/modules/microservices-tutorial/examples/02-shopping-cart-service-java/docker-compose.yml
@@ -14,20 +14,20 @@ services:
     ports:
       - 5433:5432
     environment:
-      POSTGRES_DB: shopping-cart
+      POSTGRES_DB: shopping-cart-test
       POSTGRES_USER: shopping-cart
       POSTGRES_PASSWORD: shopping-cart
 
-  # See dockerhub for different versions of kafka and zookeeper
-  # https://hub.docker.com/r/wurstmeister/kafka/
-  # https://hub.docker.com/r/wurstmeister/zookeeper/
+# See dockerhub for different versions of kafka and zookeeper
+# https://hub.docker.com/r/wurstmeister/kafka/
+# https://hub.docker.com/r/wurstmeister/zookeeper/
   zookeeper:
-    image: wurstmeister/zookeeper:3.4.6
+    image: zookeeper:3.6.2
     ports:
       - "2181:2181"
 
   kafka:
-    image: wurstmeister/kafka:2.13-2.6.0
+    image: wurstmeister/kafka:2.13-2.7.0
     ports:
       - "9092:9092"
     environment:
@@ -35,3 +35,21 @@ services:
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
+
+  kafka-consumer:
+    image: wurstmeister/kafka:2.13-2.7.0
+    command: bash -c "mkdir -vp /tmp/kafka-logs && /opt/kafka_2.13-2.7.0/bin/kafk-console-consumer.sh --zookeeper zookeeper:2181 --from-beginning --topic-name > /tmp/kafka-logs/topic-name.log"
+    ports:
+      - "9094:9092"
+    links:
+      - zookeeper
+      - kafka
+    volumes:
+      - ./kafka-1-logs:/tmp/kafka-logs
+
+  wait-for-kafka:
+    image: waisbrot/wait
+    links:
+      - kafka
+    environment:
+      - TARGETS=kafka:9092

--- a/docs-source/docs/modules/microservices-tutorial/examples/02-shopping-cart-service-scala/docker-compose.yml
+++ b/docs-source/docs/modules/microservices-tutorial/examples/02-shopping-cart-service-scala/docker-compose.yml
@@ -14,7 +14,7 @@ services:
     ports:
       - 5433:5432
     environment:
-      POSTGRES_DB: shopping-cart-test
+      POSTGRES_DB: shopping-cart
       POSTGRES_USER: shopping-cart
       POSTGRES_PASSWORD: shopping-cart
 

--- a/docs-source/docs/modules/microservices-tutorial/examples/02-shopping-cart-service-scala/docker-compose.yml
+++ b/docs-source/docs/modules/microservices-tutorial/examples/02-shopping-cart-service-scala/docker-compose.yml
@@ -22,12 +22,12 @@ services:
 # https://hub.docker.com/r/wurstmeister/kafka/
 # https://hub.docker.com/r/wurstmeister/zookeeper/
   zookeeper:
-    image: wurstmeister/zookeeper:3.4.6
+    image: zookeeper:3.6.2
     ports:
       - "2181:2181"
 
   kafka:
-    image: wurstmeister/kafka:2.13-2.6.0
+    image: wurstmeister/kafka:2.13-2.7.0
     ports:
       - "9092:9092"
     environment:
@@ -35,3 +35,21 @@ services:
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
+
+  kafka-consumer:
+    image: wurstmeister/kafka:2.13-2.7.0
+    command: bash -c "mkdir -vp /tmp/kafka-logs && /opt/kafka_2.13-2.7.0/bin/kafk-console-consumer.sh --zookeeper zookeeper:2181 --from-beginning --topic-name > /tmp/kafka-logs/topic-name.log"
+    ports:
+      - "9094:9092"
+    links:
+      - zookeeper
+      - kafka
+    volumes:
+      - ./kafka-1-logs:/tmp/kafka-logs
+
+  wait-for-kafka:
+    image: waisbrot/wait
+    links:
+      - kafka
+    environment:
+      - TARGETS=kafka:9092

--- a/docs-source/docs/modules/microservices-tutorial/examples/02-shopping-cart-service-scala/src/test/resources/persistence-test.conf
+++ b/docs-source/docs/modules/microservices-tutorial/examples/02-shopping-cart-service-scala/src/test/resources/persistence-test.conf
@@ -1,5 +1,5 @@
 jdbc-connection-settings {
-  url = "jdbc:postgresql://localhost:5433/shopping-cart-test?reWriteBatchedInserts=true"
+  url = "jdbc:postgresql://localhost:5433/shopping-cart?reWriteBatchedInserts=true"
   user = "shopping-cart"
   password = "shopping-cart"
 }

--- a/docs-source/docs/modules/microservices-tutorial/examples/03-shopping-cart-service-java/docker-compose.yml
+++ b/docs-source/docs/modules/microservices-tutorial/examples/03-shopping-cart-service-java/docker-compose.yml
@@ -14,7 +14,7 @@ services:
     ports:
       - 5433:5432
     environment:
-      POSTGRES_DB: shopping-cart-test
+      POSTGRES_DB: shopping-cart
       POSTGRES_USER: shopping-cart
       POSTGRES_PASSWORD: shopping-cart
 

--- a/docs-source/docs/modules/microservices-tutorial/examples/03-shopping-cart-service-java/docker-compose.yml
+++ b/docs-source/docs/modules/microservices-tutorial/examples/03-shopping-cart-service-java/docker-compose.yml
@@ -14,20 +14,20 @@ services:
     ports:
       - 5433:5432
     environment:
-      POSTGRES_DB: shopping-cart
+      POSTGRES_DB: shopping-cart-test
       POSTGRES_USER: shopping-cart
       POSTGRES_PASSWORD: shopping-cart
 
-  # See dockerhub for different versions of kafka and zookeeper
-  # https://hub.docker.com/r/wurstmeister/kafka/
-  # https://hub.docker.com/r/wurstmeister/zookeeper/
+# See dockerhub for different versions of kafka and zookeeper
+# https://hub.docker.com/r/wurstmeister/kafka/
+# https://hub.docker.com/r/wurstmeister/zookeeper/
   zookeeper:
-    image: wurstmeister/zookeeper:3.4.6
+    image: zookeeper:3.6.2
     ports:
       - "2181:2181"
 
   kafka:
-    image: wurstmeister/kafka:2.13-2.6.0
+    image: wurstmeister/kafka:2.13-2.7.0
     ports:
       - "9092:9092"
     environment:
@@ -35,3 +35,21 @@ services:
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
+
+  kafka-consumer:
+    image: wurstmeister/kafka:2.13-2.7.0
+    command: bash -c "mkdir -vp /tmp/kafka-logs && /opt/kafka_2.13-2.7.0/bin/kafk-console-consumer.sh --zookeeper zookeeper:2181 --from-beginning --topic-name > /tmp/kafka-logs/topic-name.log"
+    ports:
+      - "9094:9092"
+    links:
+      - zookeeper
+      - kafka
+    volumes:
+      - ./kafka-1-logs:/tmp/kafka-logs
+
+  wait-for-kafka:
+    image: waisbrot/wait
+    links:
+      - kafka
+    environment:
+      - TARGETS=kafka:9092

--- a/docs-source/docs/modules/microservices-tutorial/examples/03-shopping-cart-service-scala/docker-compose.yml
+++ b/docs-source/docs/modules/microservices-tutorial/examples/03-shopping-cart-service-scala/docker-compose.yml
@@ -14,7 +14,7 @@ services:
     ports:
       - 5433:5432
     environment:
-      POSTGRES_DB: shopping-cart-test
+      POSTGRES_DB: shopping-cart
       POSTGRES_USER: shopping-cart
       POSTGRES_PASSWORD: shopping-cart
 

--- a/docs-source/docs/modules/microservices-tutorial/examples/03-shopping-cart-service-scala/docker-compose.yml
+++ b/docs-source/docs/modules/microservices-tutorial/examples/03-shopping-cart-service-scala/docker-compose.yml
@@ -22,12 +22,12 @@ services:
 # https://hub.docker.com/r/wurstmeister/kafka/
 # https://hub.docker.com/r/wurstmeister/zookeeper/
   zookeeper:
-    image: wurstmeister/zookeeper:3.4.6
+    image: zookeeper:3.6.2
     ports:
       - "2181:2181"
 
   kafka:
-    image: wurstmeister/kafka:2.13-2.6.0
+    image: wurstmeister/kafka:2.13-2.7.0
     ports:
       - "9092:9092"
     environment:
@@ -35,3 +35,21 @@ services:
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
+
+  kafka-consumer:
+    image: wurstmeister/kafka:2.13-2.7.0
+    command: bash -c "mkdir -vp /tmp/kafka-logs && /opt/kafka_2.13-2.7.0/bin/kafk-console-consumer.sh --zookeeper zookeeper:2181 --from-beginning --topic-name > /tmp/kafka-logs/topic-name.log"
+    ports:
+      - "9094:9092"
+    links:
+      - zookeeper
+      - kafka
+    volumes:
+      - ./kafka-1-logs:/tmp/kafka-logs
+
+  wait-for-kafka:
+    image: waisbrot/wait
+    links:
+      - kafka
+    environment:
+      - TARGETS=kafka:9092

--- a/docs-source/docs/modules/microservices-tutorial/examples/03-shopping-cart-service-scala/src/test/resources/persistence-test.conf
+++ b/docs-source/docs/modules/microservices-tutorial/examples/03-shopping-cart-service-scala/src/test/resources/persistence-test.conf
@@ -1,5 +1,5 @@
 jdbc-connection-settings {
-  url = "jdbc:postgresql://localhost:5433/shopping-cart-test?reWriteBatchedInserts=true"
+  url = "jdbc:postgresql://localhost:5433/shopping-cart?reWriteBatchedInserts=true"
   user = "shopping-cart"
   password = "shopping-cart"
 }

--- a/docs-source/docs/modules/microservices-tutorial/examples/04-shopping-cart-service-java/docker-compose.yml
+++ b/docs-source/docs/modules/microservices-tutorial/examples/04-shopping-cart-service-java/docker-compose.yml
@@ -14,7 +14,7 @@ services:
     ports:
       - 5433:5432
     environment:
-      POSTGRES_DB: shopping-cart-test
+      POSTGRES_DB: shopping-cart
       POSTGRES_USER: shopping-cart
       POSTGRES_PASSWORD: shopping-cart
 

--- a/docs-source/docs/modules/microservices-tutorial/examples/04-shopping-cart-service-java/docker-compose.yml
+++ b/docs-source/docs/modules/microservices-tutorial/examples/04-shopping-cart-service-java/docker-compose.yml
@@ -14,20 +14,20 @@ services:
     ports:
       - 5433:5432
     environment:
-      POSTGRES_DB: shopping-cart
+      POSTGRES_DB: shopping-cart-test
       POSTGRES_USER: shopping-cart
       POSTGRES_PASSWORD: shopping-cart
 
-  # See dockerhub for different versions of kafka and zookeeper
-  # https://hub.docker.com/r/wurstmeister/kafka/
-  # https://hub.docker.com/r/wurstmeister/zookeeper/
+# See dockerhub for different versions of kafka and zookeeper
+# https://hub.docker.com/r/wurstmeister/kafka/
+# https://hub.docker.com/r/wurstmeister/zookeeper/
   zookeeper:
-    image: wurstmeister/zookeeper:3.4.6
+    image: zookeeper:3.6.2
     ports:
       - "2181:2181"
 
   kafka:
-    image: wurstmeister/kafka:2.13-2.6.0
+    image: wurstmeister/kafka:2.13-2.7.0
     ports:
       - "9092:9092"
     environment:
@@ -35,3 +35,21 @@ services:
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
+
+  kafka-consumer:
+    image: wurstmeister/kafka:2.13-2.7.0
+    command: bash -c "mkdir -vp /tmp/kafka-logs && /opt/kafka_2.13-2.7.0/bin/kafk-console-consumer.sh --zookeeper zookeeper:2181 --from-beginning --topic-name > /tmp/kafka-logs/topic-name.log"
+    ports:
+      - "9094:9092"
+    links:
+      - zookeeper
+      - kafka
+    volumes:
+      - ./kafka-1-logs:/tmp/kafka-logs
+
+  wait-for-kafka:
+    image: waisbrot/wait
+    links:
+      - kafka
+    environment:
+      - TARGETS=kafka:9092

--- a/docs-source/docs/modules/microservices-tutorial/examples/04-shopping-cart-service-scala/docker-compose.yml
+++ b/docs-source/docs/modules/microservices-tutorial/examples/04-shopping-cart-service-scala/docker-compose.yml
@@ -14,7 +14,7 @@ services:
     ports:
       - 5433:5432
     environment:
-      POSTGRES_DB: shopping-cart-test
+      POSTGRES_DB: shopping-cart
       POSTGRES_USER: shopping-cart
       POSTGRES_PASSWORD: shopping-cart
 

--- a/docs-source/docs/modules/microservices-tutorial/examples/04-shopping-cart-service-scala/docker-compose.yml
+++ b/docs-source/docs/modules/microservices-tutorial/examples/04-shopping-cart-service-scala/docker-compose.yml
@@ -22,12 +22,12 @@ services:
 # https://hub.docker.com/r/wurstmeister/kafka/
 # https://hub.docker.com/r/wurstmeister/zookeeper/
   zookeeper:
-    image: wurstmeister/zookeeper:3.4.6
+    image: zookeeper:3.6.2
     ports:
       - "2181:2181"
 
   kafka:
-    image: wurstmeister/kafka:2.13-2.6.0
+    image: wurstmeister/kafka:2.13-2.7.0
     ports:
       - "9092:9092"
     environment:
@@ -35,3 +35,21 @@ services:
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
+
+  kafka-consumer:
+    image: wurstmeister/kafka:2.13-2.7.0
+    command: bash -c "mkdir -vp /tmp/kafka-logs && /opt/kafka_2.13-2.7.0/bin/kafk-console-consumer.sh --zookeeper zookeeper:2181 --from-beginning --topic-name > /tmp/kafka-logs/topic-name.log"
+    ports:
+      - "9094:9092"
+    links:
+      - zookeeper
+      - kafka
+    volumes:
+      - ./kafka-1-logs:/tmp/kafka-logs
+
+  wait-for-kafka:
+    image: waisbrot/wait
+    links:
+      - kafka
+    environment:
+      - TARGETS=kafka:9092

--- a/docs-source/docs/modules/microservices-tutorial/examples/04-shopping-cart-service-scala/src/test/resources/persistence-test.conf
+++ b/docs-source/docs/modules/microservices-tutorial/examples/04-shopping-cart-service-scala/src/test/resources/persistence-test.conf
@@ -1,5 +1,5 @@
 jdbc-connection-settings {
-  url = "jdbc:postgresql://localhost:5433/shopping-cart-test?reWriteBatchedInserts=true"
+  url = "jdbc:postgresql://localhost:5433/shopping-cart?reWriteBatchedInserts=true"
   user = "shopping-cart"
   password = "shopping-cart"
 }

--- a/docs-source/docs/modules/microservices-tutorial/examples/05-shopping-cart-service-java/docker-compose.yml
+++ b/docs-source/docs/modules/microservices-tutorial/examples/05-shopping-cart-service-java/docker-compose.yml
@@ -14,7 +14,7 @@ services:
     ports:
       - 5433:5432
     environment:
-      POSTGRES_DB: shopping-cart-test
+      POSTGRES_DB: shopping-cart
       POSTGRES_USER: shopping-cart
       POSTGRES_PASSWORD: shopping-cart
 

--- a/docs-source/docs/modules/microservices-tutorial/examples/05-shopping-cart-service-java/docker-compose.yml
+++ b/docs-source/docs/modules/microservices-tutorial/examples/05-shopping-cart-service-java/docker-compose.yml
@@ -14,20 +14,20 @@ services:
     ports:
       - 5433:5432
     environment:
-      POSTGRES_DB: shopping-cart
+      POSTGRES_DB: shopping-cart-test
       POSTGRES_USER: shopping-cart
       POSTGRES_PASSWORD: shopping-cart
 
-  # See dockerhub for different versions of kafka and zookeeper
-  # https://hub.docker.com/r/wurstmeister/kafka/
-  # https://hub.docker.com/r/wurstmeister/zookeeper/
+# See dockerhub for different versions of kafka and zookeeper
+# https://hub.docker.com/r/wurstmeister/kafka/
+# https://hub.docker.com/r/wurstmeister/zookeeper/
   zookeeper:
-    image: wurstmeister/zookeeper:3.4.6
+    image: zookeeper:3.6.2
     ports:
       - "2181:2181"
 
   kafka:
-    image: wurstmeister/kafka:2.13-2.6.0
+    image: wurstmeister/kafka:2.13-2.7.0
     ports:
       - "9092:9092"
     environment:
@@ -35,3 +35,21 @@ services:
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
+
+  kafka-consumer:
+    image: wurstmeister/kafka:2.13-2.7.0
+    command: bash -c "mkdir -vp /tmp/kafka-logs && /opt/kafka_2.13-2.7.0/bin/kafk-console-consumer.sh --zookeeper zookeeper:2181 --from-beginning --topic-name > /tmp/kafka-logs/topic-name.log"
+    ports:
+      - "9094:9092"
+    links:
+      - zookeeper
+      - kafka
+    volumes:
+      - ./kafka-1-logs:/tmp/kafka-logs
+
+  wait-for-kafka:
+    image: waisbrot/wait
+    links:
+      - kafka
+    environment:
+      - TARGETS=kafka:9092

--- a/docs-source/docs/modules/microservices-tutorial/examples/05-shopping-cart-service-scala/docker-compose.yml
+++ b/docs-source/docs/modules/microservices-tutorial/examples/05-shopping-cart-service-scala/docker-compose.yml
@@ -14,7 +14,7 @@ services:
     ports:
       - 5433:5432
     environment:
-      POSTGRES_DB: shopping-cart-test
+      POSTGRES_DB: shopping-cart
       POSTGRES_USER: shopping-cart
       POSTGRES_PASSWORD: shopping-cart
 

--- a/docs-source/docs/modules/microservices-tutorial/examples/05-shopping-cart-service-scala/docker-compose.yml
+++ b/docs-source/docs/modules/microservices-tutorial/examples/05-shopping-cart-service-scala/docker-compose.yml
@@ -22,12 +22,12 @@ services:
 # https://hub.docker.com/r/wurstmeister/kafka/
 # https://hub.docker.com/r/wurstmeister/zookeeper/
   zookeeper:
-    image: wurstmeister/zookeeper:3.4.6
+    image: zookeeper:3.6.2
     ports:
       - "2181:2181"
 
   kafka:
-    image: wurstmeister/kafka:2.13-2.6.0
+    image: wurstmeister/kafka:2.13-2.7.0
     ports:
       - "9092:9092"
     environment:
@@ -35,3 +35,21 @@ services:
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
+
+  kafka-consumer:
+    image: wurstmeister/kafka:2.13-2.7.0
+    command: bash -c "mkdir -vp /tmp/kafka-logs && /opt/kafka_2.13-2.7.0/bin/kafk-console-consumer.sh --zookeeper zookeeper:2181 --from-beginning --topic-name > /tmp/kafka-logs/topic-name.log"
+    ports:
+      - "9094:9092"
+    links:
+      - zookeeper
+      - kafka
+    volumes:
+      - ./kafka-1-logs:/tmp/kafka-logs
+
+  wait-for-kafka:
+    image: waisbrot/wait
+    links:
+      - kafka
+    environment:
+      - TARGETS=kafka:9092

--- a/docs-source/docs/modules/microservices-tutorial/examples/05-shopping-cart-service-scala/src/test/resources/persistence-test.conf
+++ b/docs-source/docs/modules/microservices-tutorial/examples/05-shopping-cart-service-scala/src/test/resources/persistence-test.conf
@@ -1,5 +1,5 @@
 jdbc-connection-settings {
-  url = "jdbc:postgresql://localhost:5433/shopping-cart-test?reWriteBatchedInserts=true"
+  url = "jdbc:postgresql://localhost:5433/shopping-cart?reWriteBatchedInserts=true"
   user = "shopping-cart"
   password = "shopping-cart"
 }

--- a/docs-source/docs/modules/microservices-tutorial/examples/shopping-analytics-service-java/docker-compose.yml
+++ b/docs-source/docs/modules/microservices-tutorial/examples/shopping-analytics-service-java/docker-compose.yml
@@ -14,7 +14,7 @@ services:
     ports:
       - 5433:5432
     environment:
-      POSTGRES_DB: shopping-cart-test
+      POSTGRES_DB: shopping-cart
       POSTGRES_USER: shopping-cart
       POSTGRES_PASSWORD: shopping-cart
 

--- a/docs-source/docs/modules/microservices-tutorial/examples/shopping-analytics-service-java/docker-compose.yml
+++ b/docs-source/docs/modules/microservices-tutorial/examples/shopping-analytics-service-java/docker-compose.yml
@@ -14,20 +14,20 @@ services:
     ports:
       - 5433:5432
     environment:
-      POSTGRES_DB: shopping-cart
+      POSTGRES_DB: shopping-cart-test
       POSTGRES_USER: shopping-cart
       POSTGRES_PASSWORD: shopping-cart
 
-  # See dockerhub for different versions of kafka and zookeeper
-  # https://hub.docker.com/r/wurstmeister/kafka/
-  # https://hub.docker.com/r/wurstmeister/zookeeper/
+# See dockerhub for different versions of kafka and zookeeper
+# https://hub.docker.com/r/wurstmeister/kafka/
+# https://hub.docker.com/r/wurstmeister/zookeeper/
   zookeeper:
-    image: wurstmeister/zookeeper:3.4.6
+    image: zookeeper:3.6.2
     ports:
       - "2181:2181"
 
   kafka:
-    image: wurstmeister/kafka:2.13-2.6.0
+    image: wurstmeister/kafka:2.13-2.7.0
     ports:
       - "9092:9092"
     environment:
@@ -35,3 +35,21 @@ services:
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
+
+  kafka-consumer:
+    image: wurstmeister/kafka:2.13-2.7.0
+    command: bash -c "mkdir -vp /tmp/kafka-logs && /opt/kafka_2.13-2.7.0/bin/kafk-console-consumer.sh --zookeeper zookeeper:2181 --from-beginning --topic-name > /tmp/kafka-logs/topic-name.log"
+    ports:
+      - "9094:9092"
+    links:
+      - zookeeper
+      - kafka
+    volumes:
+      - ./kafka-1-logs:/tmp/kafka-logs
+
+  wait-for-kafka:
+    image: waisbrot/wait
+    links:
+      - kafka
+    environment:
+      - TARGETS=kafka:9092

--- a/docs-source/docs/modules/microservices-tutorial/examples/shopping-analytics-service-scala/docker-compose.yml
+++ b/docs-source/docs/modules/microservices-tutorial/examples/shopping-analytics-service-scala/docker-compose.yml
@@ -14,7 +14,7 @@ services:
     ports:
       - 5433:5432
     environment:
-      POSTGRES_DB: shopping-cart-test
+      POSTGRES_DB: shopping-cart
       POSTGRES_USER: shopping-cart
       POSTGRES_PASSWORD: shopping-cart
 

--- a/docs-source/docs/modules/microservices-tutorial/examples/shopping-analytics-service-scala/docker-compose.yml
+++ b/docs-source/docs/modules/microservices-tutorial/examples/shopping-analytics-service-scala/docker-compose.yml
@@ -22,12 +22,12 @@ services:
 # https://hub.docker.com/r/wurstmeister/kafka/
 # https://hub.docker.com/r/wurstmeister/zookeeper/
   zookeeper:
-    image: wurstmeister/zookeeper:3.4.6
+    image: zookeeper:3.6.2
     ports:
       - "2181:2181"
 
   kafka:
-    image: wurstmeister/kafka:2.13-2.6.0
+    image: wurstmeister/kafka:2.13-2.7.0
     ports:
       - "9092:9092"
     environment:
@@ -35,3 +35,21 @@ services:
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
+
+  kafka-consumer:
+    image: wurstmeister/kafka:2.13-2.7.0
+    command: bash -c "mkdir -vp /tmp/kafka-logs && /opt/kafka_2.13-2.7.0/bin/kafk-console-consumer.sh --zookeeper zookeeper:2181 --from-beginning --topic-name > /tmp/kafka-logs/topic-name.log"
+    ports:
+      - "9094:9092"
+    links:
+      - zookeeper
+      - kafka
+    volumes:
+      - ./kafka-1-logs:/tmp/kafka-logs
+
+  wait-for-kafka:
+    image: waisbrot/wait
+    links:
+      - kafka
+    environment:
+      - TARGETS=kafka:9092

--- a/docs-source/docs/modules/microservices-tutorial/examples/shopping-cart-service-java/docker-compose.yml
+++ b/docs-source/docs/modules/microservices-tutorial/examples/shopping-cart-service-java/docker-compose.yml
@@ -14,7 +14,7 @@ services:
     ports:
       - 5433:5432
     environment:
-      POSTGRES_DB: shopping-cart-test
+      POSTGRES_DB: shopping-cart
       POSTGRES_USER: shopping-cart
       POSTGRES_PASSWORD: shopping-cart
 

--- a/docs-source/docs/modules/microservices-tutorial/examples/shopping-cart-service-java/docker-compose.yml
+++ b/docs-source/docs/modules/microservices-tutorial/examples/shopping-cart-service-java/docker-compose.yml
@@ -14,20 +14,20 @@ services:
     ports:
       - 5433:5432
     environment:
-      POSTGRES_DB: shopping-cart
+      POSTGRES_DB: shopping-cart-test
       POSTGRES_USER: shopping-cart
       POSTGRES_PASSWORD: shopping-cart
 
-  # See dockerhub for different versions of kafka and zookeeper
-  # https://hub.docker.com/r/wurstmeister/kafka/
-  # https://hub.docker.com/r/wurstmeister/zookeeper/
+# See dockerhub for different versions of kafka and zookeeper
+# https://hub.docker.com/r/wurstmeister/kafka/
+# https://hub.docker.com/r/wurstmeister/zookeeper/
   zookeeper:
-    image: wurstmeister/zookeeper:3.4.6
+    image: zookeeper:3.6.2
     ports:
       - "2181:2181"
 
   kafka:
-    image: wurstmeister/kafka:2.13-2.6.0
+    image: wurstmeister/kafka:2.13-2.7.0
     ports:
       - "9092:9092"
     environment:
@@ -35,3 +35,21 @@ services:
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
+
+  kafka-consumer:
+    image: wurstmeister/kafka:2.13-2.7.0
+    command: bash -c "mkdir -vp /tmp/kafka-logs && /opt/kafka_2.13-2.7.0/bin/kafk-console-consumer.sh --zookeeper zookeeper:2181 --from-beginning --topic-name > /tmp/kafka-logs/topic-name.log"
+    ports:
+      - "9094:9092"
+    links:
+      - zookeeper
+      - kafka
+    volumes:
+      - ./kafka-1-logs:/tmp/kafka-logs
+
+  wait-for-kafka:
+    image: waisbrot/wait
+    links:
+      - kafka
+    environment:
+      - TARGETS=kafka:9092

--- a/docs-source/docs/modules/microservices-tutorial/examples/shopping-cart-service-scala/docker-compose.yml
+++ b/docs-source/docs/modules/microservices-tutorial/examples/shopping-cart-service-scala/docker-compose.yml
@@ -14,7 +14,7 @@ services:
     ports:
       - 5433:5432
     environment:
-      POSTGRES_DB: shopping-cart-test
+      POSTGRES_DB: shopping-cart
       POSTGRES_USER: shopping-cart
       POSTGRES_PASSWORD: shopping-cart
 

--- a/docs-source/docs/modules/microservices-tutorial/examples/shopping-cart-service-scala/docker-compose.yml
+++ b/docs-source/docs/modules/microservices-tutorial/examples/shopping-cart-service-scala/docker-compose.yml
@@ -22,12 +22,12 @@ services:
 # https://hub.docker.com/r/wurstmeister/kafka/
 # https://hub.docker.com/r/wurstmeister/zookeeper/
   zookeeper:
-    image: wurstmeister/zookeeper:3.4.6
+    image: zookeeper:3.6.2
     ports:
       - "2181:2181"
 
   kafka:
-    image: wurstmeister/kafka:2.13-2.6.0
+    image: wurstmeister/kafka:2.13-2.7.0
     ports:
       - "9092:9092"
     environment:
@@ -35,3 +35,21 @@ services:
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
+
+  kafka-consumer:
+    image: wurstmeister/kafka:2.13-2.7.0
+    command: bash -c "mkdir -vp /tmp/kafka-logs && /opt/kafka_2.13-2.7.0/bin/kafk-console-consumer.sh --zookeeper zookeeper:2181 --from-beginning --topic-name > /tmp/kafka-logs/topic-name.log"
+    ports:
+      - "9094:9092"
+    links:
+      - zookeeper
+      - kafka
+    volumes:
+      - ./kafka-1-logs:/tmp/kafka-logs
+
+  wait-for-kafka:
+    image: waisbrot/wait
+    links:
+      - kafka
+    environment:
+      - TARGETS=kafka:9092

--- a/docs-source/docs/modules/microservices-tutorial/examples/shopping-cart-service-scala/src/test/resources/persistence-test.conf
+++ b/docs-source/docs/modules/microservices-tutorial/examples/shopping-cart-service-scala/src/test/resources/persistence-test.conf
@@ -1,5 +1,5 @@
 jdbc-connection-settings {
-  url = "jdbc:postgresql://localhost:5433/shopping-cart-test?reWriteBatchedInserts=true"
+  url = "jdbc:postgresql://localhost:5433/shopping-cart?reWriteBatchedInserts=true"
   user = "shopping-cart"
   password = "shopping-cart"
 }

--- a/docs-source/docs/modules/microservices-tutorial/examples/shopping-order-service-java/docker-compose.yml
+++ b/docs-source/docs/modules/microservices-tutorial/examples/shopping-order-service-java/docker-compose.yml
@@ -14,7 +14,7 @@ services:
     ports:
       - 5433:5432
     environment:
-      POSTGRES_DB: shopping-cart-test
+      POSTGRES_DB: shopping-cart
       POSTGRES_USER: shopping-cart
       POSTGRES_PASSWORD: shopping-cart
 

--- a/docs-source/docs/modules/microservices-tutorial/examples/shopping-order-service-java/docker-compose.yml
+++ b/docs-source/docs/modules/microservices-tutorial/examples/shopping-order-service-java/docker-compose.yml
@@ -14,20 +14,20 @@ services:
     ports:
       - 5433:5432
     environment:
-      POSTGRES_DB: shopping-cart
+      POSTGRES_DB: shopping-cart-test
       POSTGRES_USER: shopping-cart
       POSTGRES_PASSWORD: shopping-cart
 
-  # See dockerhub for different versions of kafka and zookeeper
-  # https://hub.docker.com/r/wurstmeister/kafka/
-  # https://hub.docker.com/r/wurstmeister/zookeeper/
+# See dockerhub for different versions of kafka and zookeeper
+# https://hub.docker.com/r/wurstmeister/kafka/
+# https://hub.docker.com/r/wurstmeister/zookeeper/
   zookeeper:
-    image: wurstmeister/zookeeper:3.4.6
+    image: zookeeper:3.6.2
     ports:
       - "2181:2181"
 
   kafka:
-    image: wurstmeister/kafka:2.13-2.6.0
+    image: wurstmeister/kafka:2.13-2.7.0
     ports:
       - "9092:9092"
     environment:
@@ -35,3 +35,21 @@ services:
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
+
+  kafka-consumer:
+    image: wurstmeister/kafka:2.13-2.7.0
+    command: bash -c "mkdir -vp /tmp/kafka-logs && /opt/kafka_2.13-2.7.0/bin/kafk-console-consumer.sh --zookeeper zookeeper:2181 --from-beginning --topic-name > /tmp/kafka-logs/topic-name.log"
+    ports:
+      - "9094:9092"
+    links:
+      - zookeeper
+      - kafka
+    volumes:
+      - ./kafka-1-logs:/tmp/kafka-logs
+
+  wait-for-kafka:
+    image: waisbrot/wait
+    links:
+      - kafka
+    environment:
+      - TARGETS=kafka:9092

--- a/docs-source/docs/modules/microservices-tutorial/examples/shopping-order-service-scala/docker-compose.yml
+++ b/docs-source/docs/modules/microservices-tutorial/examples/shopping-order-service-scala/docker-compose.yml
@@ -14,7 +14,7 @@ services:
     ports:
       - 5433:5432
     environment:
-      POSTGRES_DB: shopping-cart-test
+      POSTGRES_DB: shopping-cart
       POSTGRES_USER: shopping-cart
       POSTGRES_PASSWORD: shopping-cart
 

--- a/docs-source/docs/modules/microservices-tutorial/examples/shopping-order-service-scala/docker-compose.yml
+++ b/docs-source/docs/modules/microservices-tutorial/examples/shopping-order-service-scala/docker-compose.yml
@@ -22,12 +22,12 @@ services:
 # https://hub.docker.com/r/wurstmeister/kafka/
 # https://hub.docker.com/r/wurstmeister/zookeeper/
   zookeeper:
-    image: wurstmeister/zookeeper:3.4.6
+    image: zookeeper:3.6.2
     ports:
       - "2181:2181"
 
   kafka:
-    image: wurstmeister/kafka:2.13-2.6.0
+    image: wurstmeister/kafka:2.13-2.7.0
     ports:
       - "9092:9092"
     environment:
@@ -35,3 +35,21 @@ services:
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
+
+  kafka-consumer:
+    image: wurstmeister/kafka:2.13-2.7.0
+    command: bash -c "mkdir -vp /tmp/kafka-logs && /opt/kafka_2.13-2.7.0/bin/kafk-console-consumer.sh --zookeeper zookeeper:2181 --from-beginning --topic-name > /tmp/kafka-logs/topic-name.log"
+    ports:
+      - "9094:9092"
+    links:
+      - zookeeper
+      - kafka
+    volumes:
+      - ./kafka-1-logs:/tmp/kafka-logs
+
+  wait-for-kafka:
+    image: waisbrot/wait
+    links:
+      - kafka
+    environment:
+      - TARGETS=kafka:9092

--- a/scripts/copy-identical-files.sh
+++ b/scripts/copy-identical-files.sh
@@ -94,7 +94,9 @@ cp ${SRC} ${tutorial_root}/04-shopping-cart-service-java/
 cp ${SRC} ${tutorial_root}/05-shopping-cart-service-java/
 cp ${SRC} ${tutorial_root}/shopping-cart-service-java/
 cp ${SRC} ${tutorial_root}/shopping-analytics-service-java/
+cp ${SRC} ${tutorial_root}/00-shopping-analytics-service-java/
 cp ${SRC} ${tutorial_root}/shopping-order-service-java/
+cp ${SRC} ${tutorial_root}/00-shopping-order-service-java/
 
 # scala and java project files
 # Each time we copy the file from the scala variant. They are language agnostic.


### PR DESCRIPTION
References #588 and #639

Bumps the ZooKeeper and Kafka versions.

Following [this blogpost](https://qagurusite.wordpress.com/2017/04/15/how-to-use-kafka-in-docker-compose/) I've added 2 more containers on the docker-compose that will not complete starting until Kafka is available.


If this succeeds I'll close #639  and revert #625