### PR TITLE
Deployment: make deployment less AWS-centric

### DIFF
--- a/docs-source/docs/modules/ROOT/pages/index.adoc
+++ b/docs-source/docs/modules/ROOT/pages/index.adoc
@@ -25,7 +25,7 @@ Akka’s use of the actor model provides a level of abstraction that makes it ea
 
 
 == Akka Cloud Platform
-Akka Cloud Platform enhances Akka by adding operational tooling, services, and support. It is easily accessible from marketplaces, such as AWS and GCP.
+Akka Cloud Platform enhances Akka by adding operational tooling, services, and support. It is easily accessible from marketplaces, such as xref:deployment:aws-index.adoc[AWS] and xref:deployment:gcp-install.adoc[GCP].
 
 *Why use Akka Cloud Platform?*
 

--- a/docs-source/docs/modules/ROOT/pages/index.adoc
+++ b/docs-source/docs/modules/ROOT/pages/index.adoc
@@ -7,7 +7,7 @@ This guide provides information on using the Akka Platform and Akka Cloud Platfo
 
 Akka Platform is a toolkit for building highly concurrent systems that are scalable, highly efficient, and resilient by using _Reactive Principles_. The Akka Platform includes support for Akka, additional commercial components, and is available from Lightbend as a https://www.lightbend.com/lightbend-subscription[subscription {tab-icon}, window="tab"].
 
-Akka Cloud Platform adds tooling for deployment on Kubernetes and is available from https://aws.amazon.com/marketplace/pp?sku=7hhouu843kzmgqs6besqjjsbf[Amazon Web Services (AWS) {tab-icon}, window="tab"] and https://console.cloud.google.com/marketplace/details/lightbend-public/akka-cloud-platform[Google Cloud Platform (GCP) {tab-icon}].
+Akka Cloud Platform adds tooling for deployment on Kubernetes and is available from {aws-marketplace}[Amazon Web Services (AWS) {tab-icon}, window="tab"] and {gcp-marketplace}[Google Cloud Platform (GCP) {tab-icon}].
 
 Whether you are new to _Reactive principles_, or an experienced Akka user, you will find something of use in this guide. The guide complements the {akka}[Akka reference documentation {tab-icon}, window="tab"], which presents all Akka features in detail.
 

--- a/docs-source/docs/modules/ROOT/partials/include.adoc
+++ b/docs-source/docs/modules/ROOT/partials/include.adoc
@@ -18,3 +18,7 @@
 :tab-icon: image:ROOT:new-tab.svg[width=12]
 
 :akka-blog:  https://akka.io/blog
+
+// Marketplace URLs
+:aws-marketplace: https://aws.amazon.com/marketplace/pp?sku=7hhouu843kzmgqs6besqjjsbf
+:gcp-marketplace: https://console.cloud.google.com/marketplace/details/lightbend-public/akka-cloud-platform

--- a/docs-source/docs/modules/deployment/nav.adoc
+++ b/docs-source/docs/modules/deployment/nav.adoc
@@ -4,13 +4,13 @@
 // ** xref:getting-started-with-cloud-deployment.adoc[Getting Started with Cloud Deployment]
 ** xref:deploy.adoc[Deployment workflow]
 ** xref:integrations.adoc[Integrations with databases and message brokers]
-** Deploying with Amazon Web Services (AWS)
+** xref:aws-index.adoc[Deploying with Amazon Web Services (AWS)]
 *** xref:aws-install.adoc[Installing on Amazon Elastic Kubernetes Service (EKS)]
 *** xref:aws-ecr.adoc[Using the Amazon Elastic Container Registry (ECR)]
 *** xref:aws-rds.adoc[Using the Amazon Relational Database Service (RDS)]
 *** xref:aws-msk.adoc[Using Amazon Managed Streaming for Apache Kafka (Amazon MSK)]
 *** xref:aws-ingress.adoc[Using the AWS LoadBalancer Controller and TLS Certificates]
-** Deploying with Google Cloud Platform (GCP)
+** xref:gcp-install.adoc[Deploying with Google Cloud Platform (GCP)]
 *** xref:gcp-install.adoc[Installing on Google Kubernetes Engine (GKE)]
 *** xref:gcp-sql.adoc[Using GCP Cloud SQL]
 *** xref:gcp-ingress.adoc[Using the GKE Ingress Controller and TLS Certificates]

--- a/docs-source/docs/modules/deployment/pages/aws-index.adoc
+++ b/docs-source/docs/modules/deployment/pages/aws-index.adoc
@@ -1,0 +1,32 @@
+= Deploying with Amazon Web Services (AWS)
+:page-toclevels: 3
+
+include::partial$include.adoc[]
+
+To install Akka Cloud Platform on Amazon Elastic Kubernetes Service (EKS), you must have an Amazon account and a subscription to the {aws-marketplace}[Akka Cloud Platform {tab-icon}, window="tab"].
+
+== Key Information for Akka Cloud Platform on AWS
+The links and info below provide rapid access to some of the more important information used to manage your Akka Cloud Platform.
+
+- Kubernetes Akka Platform Operator — Operator management is key. You will find details on xref:deployment:aws-install.adoc[installing]
+and xref:deployment:aws-install.adoc#_update_akka_operator[updating] the Akka Operator on the Installation in Amazon EKS page.
+
+- TLS Certificates — TLS certificates are required for external access to applications managed by Akka Cloud Platform. You will find the pertinent information within the xref:deployment:aws-ingress.adoc#_tls_certificate[AWS LoadBalancer Controller] page.
+
+- Support — Support for the Akka Cloud Platform requires registration. https://aws.amazon.com/marketplace/pp/B08TLV16XM#pdp-support[Details] regarding support, and more, can be found on the AWS Marketplace.
+
+- License expiration and renewal — You may have purchased your license by subscribing to the Akka Cloud Platform product on the AWS Marketplace, or  directly from Lightbend. In either case, the license expiration and renewal for the Akka Cloud Platform is handled as follows:
+* If the Akka Cloud Platform license expires without being renewed, your current application will continue to run, but you will no longer be able to deploy or update.
+* If you have acquired a term license directly from Lightbend, and it expires, your license will automatically revert into a pay-as-you-go license.
+* When you need to renew your license, please contact mailto:aws@lightbend.com[] with your request.
+
+== Pre-requisite Skills
+
+A familiarity with the following services and skillsets is recommended before installation.
+
+* https://kubernetes.io/docs/setup/[Basic Kubernetes knowledge {tab-icon}, window="tab"] and experience with resources such as `ServiceAccounts`,  `Roles`, and `Deployments`.
+* https://docs.aws.amazon.com/eks/latest/userguide/getting-started.html[Amazon EKS {tab-icon}, window="tab"] and its command line tool https://docs.aws.amazon.com/eks/latest/userguide/getting-started-eksctl.html[`eksctl` {tab-icon}, window="tab"].
+* https://docs.aws.amazon.com/iam/[AWS IAM {tab-icon}, window="tab"] and https://docs.aws.amazon.com/IAM/latest/UserGuide/best-practices.html[IAM security best practices {tab-icon}, window="tab"].
+* https://helm.sh/docs/intro/quickstart/[Helm {tab-icon}, window="tab"] command line tool `helm`.
+* https://yaml.org/spec/1.2/spec.html[YAML {tab-icon}, window="tab"] to define configuration for Akka Microservices deployment descriptors.
+

--- a/docs-source/docs/modules/deployment/pages/aws-install.adoc
+++ b/docs-source/docs/modules/deployment/pages/aws-install.adoc
@@ -3,18 +3,7 @@
 
 include::partial$include.adoc[]
 
-To install Akka Cloud Platform on Amazon Elastic Kubernetes Service (EKS), you must have an Amazon account and a subscription to the https://aws.amazon.com/marketplace/pp?sku=7hhouu843kzmgqs6besqjjsbf[Akka Cloud Platform {tab-icon}, window="tab"].
-
-
-== Pre-requisite Skills
-
-A familiarity with the following services and skillsets is recommended before installation.
-
-* https://kubernetes.io/docs/setup/[Basic Kubernetes knowledge {tab-icon}, window="tab"] and experience with resources such as `ServiceAccounts`,  `Roles`, and `Deployments`.
-* https://docs.aws.amazon.com/eks/latest/userguide/getting-started.html[Amazon EKS {tab-icon}, window="tab"] and its command line tool https://docs.aws.amazon.com/eks/latest/userguide/getting-started-eksctl.html[`eksctl` {tab-icon}, window="tab"].
-* https://docs.aws.amazon.com/iam/[AWS IAM {tab-icon}, window="tab"] and https://docs.aws.amazon.com/IAM/latest/UserGuide/best-practices.html[IAM security best practices {tab-icon}, window="tab"].
-* https://helm.sh/docs/intro/quickstart/[Helm {tab-icon}, window="tab"] command line tool `helm`.
-* https://yaml.org/spec/1.2/spec.html[YAML {tab-icon}, window="tab"] to define configuration for Akka Microservices deployment descriptors.
+NOTE: To install Akka Cloud Platform on Amazon Elastic Kubernetes Service (EKS), you must have an Amazon account and a subscription to the https://aws.amazon.com/marketplace/pp?sku=7hhouu843kzmgqs6besqjjsbf[Akka Cloud Platform {tab-icon}, window="tab"].
 
 == Expected Time to Install
 
@@ -105,7 +94,7 @@ kubectl apply -f https://github.com/kubernetes-sigs/metrics-server/releases/late
 
 == AWS Marketplace
 
-If you have not already done it, subscribe to the https://aws.amazon.com/marketplace/pp?sku=7hhouu843kzmgqs6besqjjsbf[Akka Cloud Platform {tab-icon}, window="tab"] by clicking the Subscribe button on the product page and accepting the terms and conditions.
+If you have not already done it, subscribe to the {aws-marketplace}[Akka Cloud Platform {tab-icon}, window="tab"] by clicking the Subscribe button on the product page and accepting the terms and conditions.
 
 == Create a service account for the Akka Operator
 

--- a/docs-source/docs/modules/deployment/pages/gcp-install.adoc
+++ b/docs-source/docs/modules/deployment/pages/gcp-install.adoc
@@ -8,11 +8,11 @@ To install Akka Cloud Platform on Google Kubernetes Engine (GKE), you must have 
 If you are a first time GCP user, please follow these steps:
 
 . Create your Google account at https://console.cloud.google.com[https://console.cloud.google.com {tab-icon}, window="tab"].
-.  Create a project.
+. Create a project.
 
 == Deploy from marketplace
 
-With your account and project ready, open the https://console.cloud.google.com/marketplace/details/lightbend-public/akka-cloud-platform[Akka Cloud Platform {tab-icon}], or go to https://console.cloud.google.com/kubernetes/application[Kubernetes Engine Applications {tab-icon}, window="tab"] and search for "Akka Cloud Platform”. When you are on the product page, go ahead and purchase a plan.
+With your account and project ready, open the {gcp-marketplace}[Akka Cloud Platform {tab-icon}], or go to https://console.cloud.google.com/kubernetes/application[Kubernetes Engine Applications {tab-icon}, window="tab"] and search for "Akka Cloud Platform”. When you are on the product page, go ahead and purchase a plan.
 
 Once you've purchased a plan to use the Akka Cloud Platform, proceed to configure it. Make sure you have a project selected on the GUI or the options to purchase and configure will be disabled.
 

--- a/docs-source/docs/modules/deployment/pages/index.adoc
+++ b/docs-source/docs/modules/deployment/pages/index.adoc
@@ -1,10 +1,8 @@
 = Akka Cloud Platform
 
-include::ROOT:partial$include.adoc[]
+include::partial$include.adoc[]
 
 The Akka Cloud Platform enables developers to quickly build and deploy cloud-native Microservices on their cloud service provider of choice. It provides frameworks and runtimes for building cloud-native applications that easily integrate with other services in your chosen ecosystem.
-
-The Akka Cloud Platform is currently available for deploying Akka applications. It is available through the https://aws.amazon.com/marketplace/pp?sku=7hhouu843kzmgqs6besqjjsbf[AWS Marketplace {tab-icon}, window="tab"] to install on your Amazon EKS cluster.
 
 An Akka Cloud Platform subscription includes access to Lightbend Telemetry, Lightbend Academy, and basic support. Through the Akka Operator, the Akka Cloud Platform provides the following high level features:
 
@@ -17,13 +15,14 @@ An Akka Cloud Platform subscription includes access to Lightbend Telemetry, Ligh
 * support for gRPC and HTTP services and internet-facing ingress
 * insights into deployment status
 
+The Akka Cloud Platform is currently available in xref:gcp-install.adoc[Google Cloud Platform (GCP)] and xref:aws-index.adoc[Amazon Web Services (AWS)]
 
 == Getting Started with Cloud Deployment
 Before you can get started with cloud deployment you should:
 
 . Determine which platform you will be using (Google Cloud Platform, for example).
 . Have an active account with your chosen platform.
-. Subscribe to the Akka Cloud Platform with xref:gcp-install.adoc[GCP] or xref:aws-install.adoc[AWS].
+. Subscribe to the Akka Cloud Platform with xref:gcp-install.adoc[GCP] or xref:aws-index.adoc[AWS].
 . Set up your xref:microservices-tutorial:dev-env.adoc[environment].
 
 Once you have these in hand review the xref:cloud-deployment.adoc[] page and then proceed to the section appropriate to your platform.
@@ -31,18 +30,3 @@ Once you have these in hand review the xref:cloud-deployment.adoc[] page and the
 * xref:gcp-install.adoc[]
 * xref:aws-install.adoc[]
 
-
-== Key Information for Akka Cloud Platform on AWS
-The links and info below provide rapid access to some of the more important information used to manage your Akka Cloud Platform.
-
-- Kubernetes Akka Platform Operator — Operator management is key. You will find details on xref:deployment:aws-install.adoc[installing]
-and xref:deployment:aws-install.adoc#_update_akka_operator[updating] the Akka Operator on the Installation in Amazon EKS page.
-
-- TLS Certificates — TLS certificates are required for external access to applications managed by Akka Cloud Platform. You will find the pertinent information within the xref:deployment:aws-ingress.adoc#_tls_certificate[AWS LoadBalancer Controller] page.
-
-- Support — Support for the Akka Cloud Platform requires registration. https://aws.amazon.com/marketplace/pp/B08TLV16XM#pdp-support[Details] regarding support, and more, can be found on the AWS Marketplace.
-
-- License expiration and renewal — You may have purchased your license by subscribing to the Akka Cloud Platform product on the AWS Marketplace, or  directly from Lightbend. In either case, the license expiration and renewal for the Akka Cloud Platform is handled as follows:
-* If the Akka Cloud Platform license expires without being renewed, your current application will continue to run, but you will no longer be able to deploy or update.
-* If you have acquired a term license directly from Lightbend, and it expires, your license will automatically revert into a pay-as-you-go license.
-* When you need to renew your license, please contact mailto:aws@lightbend.com[] with your request.


### PR DESCRIPTION
Reviews the deployment section to make it less AWS-centric.

Other changes: 

- extract URLs and use antora replacement
- introduce `aws-index.adoc` to remove some AWS-specific content from other places (index.adoc and aws-install.adoc)
- makes the items on the `deployment/nav.adoc` clickable. In AWS I linked to a new `aws-index.adoc` while in GCP I linked to the existing `gcp-install.adoc`
