### PR TITLE
Add explicit namespace to the get ingress commands

### DIFF
--- a/docs-source/docs/modules/deployment/pages/aws-ingress.adoc
+++ b/docs-source/docs/modules/deployment/pages/aws-ingress.adoc
@@ -83,7 +83,7 @@ You can retrieve the public address with:
 
 [source,shell script]
 ----
-kubectl get ingress shopping-order-service-grpc-ingress
+kubectl get ingress shopping-order-service-grpc-ingress --namespace=shopping
 ----
 
 To access the public endpoint with grpcurl you use the public address from above, with port 443:

--- a/docs-source/docs/modules/deployment/pages/gcp-ingress.adoc
+++ b/docs-source/docs/modules/deployment/pages/gcp-ingress.adoc
@@ -74,7 +74,7 @@ You can retrieve the public address with:
 
 [source,shell script]
 ----
-kubectl get ingress shopping-order-service-grpc-ingress
+kubectl get ingress shopping-order-service-grpc-ingress --namespace=shopping
 ----
 
 To access the public endpoint with grpcurl you use the public address from above, with port 443:


### PR DESCRIPTION
It should help to avoid confusion when the default namespace is not `shopping`

Resolves #https://github.com/lightbend/akka-platform-meta/issues/166
