### PR TITLE
Revert "Add AWS Load Balance Controller Helm chart link"

### DIFF
--- a/docs-source/docs/modules/deployment/pages/aws-ingress.adoc
+++ b/docs-source/docs/modules/deployment/pages/aws-ingress.adoc
@@ -7,7 +7,7 @@ To expose your application's gRPC or HTTPS endpoints publicly to the internet yo
 
 == Install the LoadBalancer Controller
 
-Follow the instructions in the https://docs.aws.amazon.com/eks/latest/userguide/aws-load-balancer-controller.html[AWS Load Balancer Controller installation documentation {tab-icon}, window="tab"]
+Follow the instructions in the https://docs.aws.amazon.com/eks/latest/userguide/aws-load-balancer-controller.html[AWS Load Balancer Controller installation documentation {tab-icon}, window="tab"]. Additional information and resources can be found in the https://github.com/aws/eks-charts/tree/master/stable/aws-load-balancer-controller[AWS Load Balancer Controller Helm chart for Kubernetes Github Repo {tab-icon}, window="tab"]
 
 [#_tls_certificate]
 == TLS certificate

--- a/docs-source/docs/modules/deployment/pages/aws-ingress.adoc
+++ b/docs-source/docs/modules/deployment/pages/aws-ingress.adoc
@@ -7,7 +7,7 @@ To expose your application's gRPC or HTTPS endpoints publicly to the internet yo
 
 == Install the LoadBalancer Controller
 
-Follow the instructions in the https://github.com/aws/eks-charts/tree/master/stable/aws-load-balancer-controller[AWS Load Balancer Controller Helm chart for Kubernetes {tab-icon}, window="tab"] or https://docs.aws.amazon.com/eks/latest/userguide/aws-load-balancer-controller.html[AWS Load Balancer Controller installation documentation {tab-icon}, window="tab"]
+Follow the instructions in the https://docs.aws.amazon.com/eks/latest/userguide/aws-load-balancer-controller.html[AWS Load Balancer Controller installation documentation {tab-icon}, window="tab"]
 
 [#_tls_certificate]
 == TLS certificate


### PR DESCRIPTION
Reverts akka/akka-platform-guide#673

I noticed that the GH link doesn't mention the additional Helm settings that are required.
We can add the link as a reference, but shouldn't be the first go-to link.
Also, we should direct people in one direction, possibly.