### PR TITLE
Some changes for GKE ingress text.

### DIFF
--- a/docs-source/docs/modules/deployment/pages/gcp-ingress.adoc
+++ b/docs-source/docs/modules/deployment/pages/gcp-ingress.adoc
@@ -3,13 +3,14 @@
 
 include::partial$include.adoc[]
 
-The Akka Platform Operator supports creating two ingresses. These ingresses are meant to serve HTTP and gRPC traffic. Both ingresses are implemented using the https://cloud.google.com/kubernetes-engine/docs/concepts/ingress[GKE Ingress Controller {tab-icon}, window="tab"].
+To expose your application's gRPC or HTTPS endpoints publicly to the internet you can use the https://cloud.google.com/kubernetes-engine/docs/concepts/ingress[GKE Ingress Controller {tab-icon}, window="tab"] with a https://kubernetes.io/docs/concepts/services-networking/ingress/[Kubernetes Ingress {tab-icon}, window="tab"] created by the Akka Operator. This is useful when external services, or clients beyond the GKE cluster need to consume the gRPC or HTTPS endpoints.
+For the Akka Operator to manage ingress into your HTTP and GRPC endpoints on GKE via the cloud-native controllers, you need to setup a VPC-native cluster. Please find instructions at https://cloud.google.com/kubernetes-engine/docs/how-to/alias-ips[https://cloud.google.com/kubernetes-engine/docs/how-to/alias-ips {tab-icon}, window="tab"] to setup a VPC-native cluster. You can read about the benefits of a VPC-native cluster at https://cloud.google.com/kubernetes-engine/docs/concepts/alias-ips[https://cloud.google.com/kubernetes-engine/docs/concepts/alias-ips {tab-icon}, window="tab].
 
 == Container native load balancing
 
-Exposing the Akka Management port, as opposed to the gRPC and HTTP ports, is only possible using the  https://cloud.google.com/kubernetes-engine/docs/how-to/container-native-load-balancing[container-native load balancing {tab-icon}, window="tab"].
-
-If you override the readiness probe to a path on your HTTP port, this will also be used for the load balancer health check.
+The Akka Operator depends on https://cloud.google.com/kubernetes-engine/docs/how-to/container-native-load-balancing[container-native load balancing {tab-icon}, window="tab"] for setting up ingress on GKE.
+Container-native load balancing allows load balancers to target Kubernetes Pods directly and to evenly distribute traffic to Pods.
+The Akka Management port is used for the load balancer health check. If you override the readiness probe to a path on your HTTP port, this will also be used for the load balancer health check.
 
 == TLS certificate
 


### PR DESCRIPTION
Some improvements to GKE ingress to make the text more clear. Also added the fact that you need to have setup a VPC-native cluster.