### PR TITLE
Update gcp-install.adoc

### DIFF
--- a/docs-source/docs/modules/deployment/pages/gcp-install.adoc
+++ b/docs-source/docs/modules/deployment/pages/gcp-install.adoc
@@ -18,14 +18,14 @@ See https://cloud.google.com/compute/docs/console[https://cloud.google.com/compu
 
 == Deploy from marketplace
 
-With your account and project ready, open the {gcp-marketplace}[Akka Cloud Platform {tab-icon}], or go to https://console.cloud.google.com/kubernetes/application[Kubernetes Engine Applications {tab-icon}, window="tab"] and search for "Akka Cloud Platform”. When you are on the product page, go ahead and purchase a plan.
+The Akka Operator manages ingress into your HTTP and GRPC endpoints via cloud-native controllers, which requires a VPC-native cluster. Please find instructions at https://cloud.google.com/kubernetes-engine/docs/how-to/alias-ips[https://cloud.google.com/kubernetes-engine/docs/how-to/alias-ips {tab-icon}, window="tab"] to setup a VPC-native cluster. You can read about the benefits of a VPC-native cluster at https://cloud.google.com/kubernetes-engine/docs/concepts/alias-ips[https://cloud.google.com/kubernetes-engine/docs/concepts/alias-ips {tab-icon}, window="tab]. 
+
+With your account, project, and cluster ready, open the {gcp-marketplace}[Akka Cloud Platform {tab-icon}], or go to https://console.cloud.google.com/kubernetes/application[Kubernetes Engine Applications {tab-icon}, window="tab"] and search for "Akka Cloud Platform”. When you are on the product page, go ahead and purchase a plan.
 
 Once you've purchased a plan to use the Akka Cloud Platform, proceed to configure it, click `Configure`. Make sure you have a project selected on the GUI or the options to purchase and configure will be disabled.
 
 To completely configure and use the Akka Cloud Platform you need to fill in a few fields:
 
-. The GKE cluster — This is the cluster where you are installing the operator. Use "Create a new cluster" if you don't have one. 
-. If you want to use Akka Operator to manage ingress into your HTTP and GRPC endpoints via the cloud-native controllers, you need to setup a VPC-native cluster. Please find instructions at https://cloud.google.com/kubernetes-engine/docs/how-to/alias-ips[https://cloud.google.com/kubernetes-engine/docs/how-to/alias-ips {tab-icon}, window="tab"] to setup a VPC-native cluster. You can read about the benefits of a VPC-native cluster at https://cloud.google.com/kubernetes-engine/docs/concepts/alias-ips[https://cloud.google.com/kubernetes-engine/docs/concepts/alias-ips {tab-icon}, window="tab].
 . A Namespace — Keeping the Marketplace offering in a specific namespace will ease follow up operations and will enforce separation of concerns.
 . An App instance name — Select a unique name. We recommend using the default or `akka-platform-operator-1`.
 . The akka-operator.serviceAccount.name — This is the name of the service account used by the operator to access Kubernetes resources.


### PR DESCRIPTION
It is no longer possible to create a new cluster from the GCP marketplace install page. We have removed this option. A default cluster that would be created by using the create new cluster is not VPC-native. It is required for the cluster to be VPC-native. The way the akka operator sets up ingresses requires the cluster to use alias IP address ranges, see: https://cloud.google.com/kubernetes-engine/docs/concepts/alias-ips