### PR TITLE
URL validation rule updates

### DIFF
--- a/.github/workflows/link-validator.yml
+++ b/.github/workflows/link-validator.yml
@@ -36,4 +36,4 @@ jobs:
         run: curl -fLo cs https://git.io/coursier-cli-linux && chmod +x cs && ./cs
 
       - name: Run Link Validator
-        run: ./cs launch net.runne::site-link-validator:0.2.0 -- scripts/validator.conf
+        run: ./cs launch net.runne::site-link-validator:0.2.1 -- scripts/validator.conf

--- a/docs-source/docs/modules/ROOT/partials/include.adoc
+++ b/docs-source/docs/modules/ROOT/partials/include.adoc
@@ -21,5 +21,5 @@
 :akka-blog:  https://akka.io/blog
 
 // Marketplace URLs
-:aws-marketplace: https://aws.amazon.com/marketplace/pp?sku=7hhouu843kzmgqs6besqjjsbf
+:aws-marketplace: https://aws.amazon.com/marketplace/pp/B08TLV16XM
 :gcp-marketplace: https://console.cloud.google.com/marketplace/details/lightbend-public/akka-cloud-platform

--- a/docs-source/docs/modules/concepts/pages/index.adoc
+++ b/docs-source/docs/modules/concepts/pages/index.adoc
@@ -37,9 +37,9 @@ From the early days of object-oriented programming and service-oriented architec
 Rather than interacting by remote invocation, Microservices publish their capabilities through a protocol. Communication is asynchronous to increase concurrency. Microservices cooperate and collaborate without being tightly coupled. Isolation and autonomy enables new development and deployment patterns:
 
 - Small, independent teams can be each be responsible for one Microservice.
-- Microservices can be monitored, tested, and debugged independently. 
+- Microservices can be monitored, tested, and debugged independently.
 - Microservices can be upgraded frequently without impacting the other services in the system, supporting continuous integration.
-- Microservices can scale up and down and in and out, by simply adding and removing instances. 
+- Microservices can scale up and down and in and out, by simply adding and removing instances.
 - When failures bring down one Microservice instance, the node on which it is running, or the network, failure does not cascade through the system.
 
 These deployment patterns require xref:mobility.adoc[mobility and addressability]. Microservices should be location independent so that instances of a particular Microservice can be deployed on any available node. When the number of instances and location change dynamically, a level of indirection shields clients and other services from what is going on behind the scenes. Service discovery mechanisms allow third parties to find and communicate with a Microservice without being aware of how many instances are running or where they are running.
@@ -56,7 +56,7 @@ image::events-first.svg[Events First]
 
 Events provide a record of what happens to each entity and when it happened. A Microservice can publish events to durable storage, a so-called event log. Other Microservices or external systems can then access those events. This decouples Microservices from each other. The event log supports recovery with a history that can be replayed. It also provides an excellent basis for auditing and debugging.
 
-For more information about DDD and Events-First design, take the free, self paced https://cognitiveclass.ai/courses/course-v1:Lightbend+LB0101ENv1+2018[Introduction to Reactive Architecture {tab-icon}, window="tab"] course.
+For more information about DDD and Events-First design, take the free, self paced https://cognitiveclass.ai/courses/reactive-architecture-introduction[Introduction to Reactive Architecture {tab-icon}, window="tab"] course.
 
 == Eventual Consistency
 
@@ -66,7 +66,7 @@ Eventual Consistency accurately reflects how the world works. The things we obse
 
 == Microservice communication patterns
 
-The WAR and JAR monolithic deployments of traditional architectures were based on assumptions about the availability of objects. In most cases, requests and responses could be treated as if they were simply local method invocations. While simple, this pattern obscures the network and pretends that it is reliable. 
+The WAR and JAR monolithic deployments of traditional architectures were based on assumptions about the availability of objects. In most cases, requests and responses could be treated as if they were simply local method invocations. While simple, this pattern obscures the network and pretends that it is reliable.
 
 In distributed systems, there are no assurances that the service you want to invoke will be running, whether a network issue will prevent a request from arriving, or whether the response will ever come. This dynamic nature of distributed systems makes it important to deal with communication failures as normal occurrences. Messages provide a resilient way of communicating between instances of the same Microservice and other Microservices in the system.
 
@@ -78,7 +78,7 @@ Messages offer a real world model that allow you to reason logically about requi
 - If the response is necessary--but not time sensitive--you might tape the note to the desk to make sure it doesn't get lost and try again if you don’t get a response.
 - If the message has value for a limited time and is not critical (such as lunch invitation, which has no value once the lunch is over) you might just leave the note and forget it.
 
-The desired outcome determines how you handle the message. Effectively, you need to choose between synchronous and asynchronous messaging. In synchronous messaging, a requestor passes a message to another service and expects a timely response, so the requestor waits. This is the familiar pattern often seen in HTTP calls between a client and server. 
+The desired outcome determines how you handle the message. Effectively, you need to choose between synchronous and asynchronous messaging. In synchronous messaging, a requestor passes a message to another service and expects a timely response, so the requestor waits. This is the familiar pattern often seen in HTTP calls between a client and server.
 
 In contrast, with asynchronous messaging, the requestor simply sends a message and continues with its business. Since Microservices depend on the health of their host and network connections, asynchronous messaging offers an obvious advantage. The illustration below illustrates how processing requests asynchronously can speed up execution.
 
@@ -86,11 +86,11 @@ image::async-sync.svg[Synchronous vs Asynchronous]
 
 If the message is important, you need some way of persisting it to make sure it will be dealt with at some point in time. An event-driven architecture offers several ways of handling this. For example, in a Microservices system, you could use a message broker with delivery guarantees, or write such messages to a database or log. If a reply is required, the sender could just wait for an acknowledgement that the request was received and continue its work, expecting the answer to the question later.
 
-== Choosing the right message for the job 
+== Choosing the right message for the job
 
 When designing a reactive Microservice system, you want to choose the best messaging pattern for the purpose. To analyze message needs, it is helpful to categorize the contents as queries, commands, or facts:
 
-- Queries often require a response in timely fashion. For example, Fred uses an ATM to find the balance on his checking account. He expects a response and if he doesn't receive one, he wants to know why. Synchronous messaging meets this objective. 
+- Queries often require a response in timely fashion. For example, Fred uses an ATM to find the balance on his checking account. He expects a response and if he doesn't receive one, he wants to know why. Synchronous messaging meets this objective.
 - Commands are requests for another service to do something, where the requestor usually needs an answer or an acknowledgement. For example, Fred initiates an ATM withdrawal of one hundred dollars from his checking account. He wants his money now, and if it isn't forthcoming, he again wants to know why. A slightly different case might be when Fred changes his PIN online, he needs to know whether it succeeded. Both of these use cases also motivate some type of synchronous communication.
 - Events carry or represent historical facts that cannot be changed. Asynchronous messaging is the most efficient and robust way to communicate them. To continue our example, when Fred receives his money, it is a fact that he withdrew one hundred dollars from his checking account. He can redeposit the money, spend it or lose it, but that doesn't change the withdrawal event.
 

--- a/docs-source/docs/modules/deployment/pages/astra.adoc
+++ b/docs-source/docs/modules/deployment/pages/astra.adoc
@@ -7,7 +7,7 @@ To use https://www.datastax.com/products/datastax-astra[DataStax Astra {tab-icon
 
 * `username` - the database username
 * `password` - the database password
-* `secureConnectBundleKey` - the secure connect bundle (zip file) that is downloaded as described in https://docs.astra.datastax.com/docs/obtaining-database-credentials[Obtain database credentials documentation {tab-icon}, window="tab"]
+* `secureConnectBundleKey` - the secure connect bundle (zip file) that is downloaded as described in https://docs.datastax.com/en/astra/docs/obtaining-database-credentials.html[Obtain database credentials documentation {tab-icon}, window="tab"]
 
 The Secret can be created with for example:
 

--- a/docs-source/docs/modules/deployment/pages/aws-install.adoc
+++ b/docs-source/docs/modules/deployment/pages/aws-install.adoc
@@ -3,7 +3,7 @@
 
 include::partial$include.adoc[]
 
-NOTE: To install Akka Cloud Platform on Amazon Elastic Kubernetes Service (EKS), you must have an Amazon account and a subscription to the https://aws.amazon.com/marketplace/pp?sku=7hhouu843kzmgqs6besqjjsbf[Akka Cloud Platform {tab-icon}, window="tab"].
+NOTE: To install Akka Cloud Platform on Amazon Elastic Kubernetes Service (EKS), you must have an Amazon account and a subscription to the {aws-marketplace}[Akka Cloud Platform {tab-icon}, window="tab"].
 
 == Expected Time to Install
 
@@ -18,7 +18,7 @@ A new installation will take approximately _40 minutes_.
 
 To install and use the Akka Cloud Platform, you must have the following tools installed. We recommend using the latest versions of these tools. If you do not have them yet or need to update, we provide links to installation instructions:
 
-* The Kubernetes command-line tool, `kubectl`, allows you to run commands against Kubernetes clusters. Follow the instructions in the https://kubernetes.io/docs/tasks/tools/install-kubectl[Kubernetes documentation {tab-icon}, window="tab"]  to install `kubectl`.
+* The Kubernetes command-line tool, `kubectl`, allows you to run commands against Kubernetes clusters. Follow the instructions in the https://kubernetes.io/docs/tasks/tools/#kubectl[Kubernetes documentation {tab-icon}, window="tab"]  to install `kubectl`.
 
 * Helm is required to install the Akka Operator in the Kubernetes cluster. Follow the instructions in the https://helm.sh/docs/intro/install/[Helm documentation {tab-icon}, window="tab"]  to install `helm`.
 

--- a/docs-source/docs/modules/deployment/pages/aws-rds.adoc
+++ b/docs-source/docs/modules/deployment/pages/aws-rds.adoc
@@ -26,7 +26,7 @@ For a trial PostgreSQL you can select the following aside from defaults:
 
 The security group will automatically have one role added to it which allows traffic from your current IP to the PostgreSQL port. If your IP changes then you'll need to update the security group.
 
-You find more detailed instructions in the https://aws.amazon.com/getting-started/tutorials/create-connect-postgresql-db/[Amazon RDS PostgreSQL documentation {tab-icon}, window="tab"]
+You can find more detailed instructions in the https://aws.amazon.com/getting-started/hands-on/create-connect-postgresql-db/[Amazon RDS PostgreSQL documentation {tab-icon}, window="tab"]
 
 == Allow EKS security group
 

--- a/docs-source/docs/modules/deployment/pages/strimzi.adoc
+++ b/docs-source/docs/modules/deployment/pages/strimzi.adoc
@@ -44,7 +44,7 @@ kubectl get pods
 
 To create a Kafka cluster using Strimzi, create the custom resource for the Strimzi Kafka operator.
 
-Create a file `kubernetes/strimzi-cr.yml` according to one of the examples in https://github.com/strimzi/strimzi-kafka-operator/tree/master/examples/kafka[strimzi-kafka-operator/examples/kafka/ {tab-icon}, window="tab"]. See configuration options in the https://strimzi.io/docs/operators/latest/using.html[Strimzi documentation {tab-icon}, window="tab"].
+Create a file `kubernetes/strimzi-cr.yml` according to one of the examples in https://github.com/strimzi/strimzi-kafka-operator/tree/main/examples/kafka[strimzi-kafka-operator/examples/kafka/ {tab-icon}, window="tab"]. See configuration options in the https://strimzi.io/docs/operators/latest/using.html[Strimzi documentation {tab-icon}, window="tab"].
 
 Note that the `topicOperator` should be included to be able to <<Create topic>>.
 

--- a/docs-source/docs/modules/telemetry/pages/getting-started.adoc
+++ b/docs-source/docs/modules/telemetry/pages/getting-started.adoc
@@ -12,7 +12,7 @@ Lightbend provides two essential pieces for Monitoring your deployments; Telemet
 
 == Subscriptions and credentials
 
-Use of Lightbend Telemetry requires a subscription and credentials. A Lightbend subscription includes open source components that are distributed from the https://maven.apache.org/repository/[Maven Central Repository], as well as the commercial components which are distributed from a private repository. A https://www.lightbend.com/lightbend-platform-subscription[Lightbend Subscription] entitles you to use all commercial features and includes https://www.lightbend.com/lightbend-platform-subscription[support] and access to https://academy.lightbend.com/dashboard/[Lightbend Academy].
+Use of Lightbend Telemetry requires a subscription and credentials. A Lightbend subscription includes open source components that are distributed from the https://maven.apache.org/repository/[Maven Central Repository], as well as the commercial components which are distributed from a private repository. A https://www.lightbend.com/lightbend-subscription[Lightbend Subscription] entitles you to use all commercial features and includes https://www.lightbend.com/lightbend-subscription[support] and access to https://academy.lightbend.com/[Lightbend Academy].
 
 Lightbend Telemetry is also available by subscription to the Akka Cloud Platform which is via {aws-marketplace}[Amazon Web Services (AWS) {tab-icon}, window="tab"] or {gcp-marketplace}[Google Cloud Platform (GCP) {tab-icon}].
 
@@ -202,7 +202,7 @@ include::example$telemetry-sample/build.sbt[tag=telemetry-javaagent-docker]
 
 == Telemetry Configuration
 
-Lightbend Telemetry supports a {cinnamon-docs}/plugins/chmetrics/reporters.html#reporters[reporter {tab-icon}, window="tab"] that can be used to see the metrics locally in your terminal. 
+Lightbend Telemetry supports a {cinnamon-docs}/plugins/chmetrics/reporters.html#reporters[reporter {tab-icon}, window="tab"] that can be used to see the metrics locally in your terminal.
 
 .src/main/resources/telemetry.conf
 [source,hocon]

--- a/docs-source/supplemental_ui/partials/footer-nav.hbs
+++ b/docs-source/supplemental_ui/partials/footer-nav.hbs
@@ -24,7 +24,7 @@
 	<section>
 		<h3>Resources</h3>
 		<ul>
-			<li><a data-category="Link - Footer - Lightbend Docs" href="https://portal.lightbend.com/">Customer Portal</a></li>
+			<li><a data-category="Link - Footer - Lightbend Docs" href="https://portal.lightbend.com/account/login">Customer Portal</a></li>
 			<li><a data-category="Link - Footer - Lightbend Docs" href="https://discuss.lightbend.com">Discussion Forums</a></li>
 			<li><a data-category="Link - Footer - Lightbend Docs" href="https://www.lightbend.com/blog">Lightbend Blog</a></li>
 			<li><a data-category="Link - Footer - Lightbend Docs" href="https://academy.lightbend.com/">Lightbend Academy</a></li>

--- a/docs-source/supplemental_ui/partials/header-content.hbs
+++ b/docs-source/supplemental_ui/partials/header-content.hbs
@@ -41,7 +41,7 @@
             <span class="navbar-link">Resources</span>
             <div class="navbar-dropdown">
               <section>
-                  <a data-category="Link - Drop Down Link - Lightbend Docs" href="https://portal.lightbend.com/">Customer Portal</a>
+                  <a data-category="Link - Drop Down Link - Lightbend Docs" href="https://portal.lightbend.com/account/login">Customer Portal</a>
                   <a data-category="Link - Drop Down Link - Lightbend Docs" href="https://discuss.lightbend.com">Discussion Forums</a>
                   <a data-category="Link - Drop Down Link - Lightbend Docs" href="https://www.lightbend.com/blog">Lightbend Blog</a>
                   <a data-category="Link - Drop Down Link - Lightbend Docs" href="https://academy.lightbend.com/">Lightbend Academy</a>

--- a/scripts/validator.conf
+++ b/scripts/validator.conf
@@ -26,7 +26,7 @@ site-link-validator {
     # redirects to login if not logged in
     "https://www.lightbend.com/account/lightbend-platform/credentials",
     # akka-http returns 403
-    "https://aws.amazon.com/marketplace/pp/B08TLV16XM"
+    #"https://aws.amazon.com/marketplace/pp/B08TLV16XM"
   ]
 
   non-https-whitelist = [

--- a/scripts/validator.conf
+++ b/scripts/validator.conf
@@ -17,5 +17,19 @@ site-link-validator {
   ignore-prefixes = [
     # These redirect to ensure the GitHub login
     "https://github.com/akka/akka-platform-guide/edit/"
+    # Telemetry examples
+    "http://localhost",
+    # 401s if not logged in
+    "https://console.aws.amazon.com/",
+    # redirects to login if not logged in
+    "https://console.cloud.google.com",
+    # redirects to login if not logged in
+    "https://www.lightbend.com/account/lightbend-platform/credentials",
+    # akka-http returns 403
+    #"https://aws.amazon.com/marketplace/pp/B08TLV16XM"
+  ]
+
+  non-https-whitelist = [
+    "http://scalikejdbc.org/"
   ]
 }

--- a/scripts/validator.conf
+++ b/scripts/validator.conf
@@ -26,7 +26,7 @@ site-link-validator {
     # redirects to login if not logged in
     "https://www.lightbend.com/account/lightbend-platform/credentials",
     # akka-http returns 403
-    #"https://aws.amazon.com/marketplace/pp/B08TLV16XM"
+    "https://aws.amazon.com/marketplace/pp/B08TLV16XM"
   ]
 
   non-https-whitelist = [


### PR DESCRIPTION
The link validator was silently failing. There were some violations, but the github action didn't return an error.

I have an [upstream fix for the validator](https://github.com/ennru/site-link-validator/pull/3), but this PR fixes the violations in the platform guide in the meantime. These updates are not critical, no URLs are actually broken.