### PR TITLE
Fail script in case of intermediate error

### DIFF
--- a/scripts/prepare-downloads.sh
+++ b/scripts/prepare-downloads.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -e
+
 declare -r tutorial_sources="${PWD}/docs-source/docs/modules/microservices-tutorial/examples"
 declare -r tutorial_attachments="${PWD}/docs-source/docs/modules/microservices-tutorial/assets/attachments"
 

--- a/scripts/prepare-downloads.sh
+++ b/scripts/prepare-downloads.sh
@@ -59,6 +59,7 @@ function zipAndAttach() {
    removeTags
    zip --quiet -r ${zip_name} *
    cp ${zip_name} ${temporal_attachments}
+   echo "Prepared attachment at ${temporal_attachments}/${zip_name}"
    popd
 }
 

--- a/scripts/prepare-downloads.sh
+++ b/scripts/prepare-downloads.sh
@@ -46,6 +46,7 @@ function prepareTemporalFolder() {
 function fetchProject() {
    source_name=$1
    target_name=$2
+   echo "Fetching content from [$1] to [$2]"
    cp -a ${source_name} ${temporal_folder}/${target_name}
 }
 
@@ -53,6 +54,7 @@ function fetchProject() {
 ## attachment file (aka, the ZIP file on the appropriate location)
 function zipAndAttach() {
    zip_name=$1
+   echo "Preparing ZIP $1"
    pushd ${temporal_folder}
    removeTags
    zip --quiet -r ${zip_name} *


### PR DESCRIPTION
References #705

The script I'm modifying is not cross-platform, it uses some linux-especific syntax for `sed` and I haven't tested it yet. 

Apart from the platform-specific syntax, it's possible this script failed silently in some step before if/when a replace operation didn't find anything to replace of the source/target folders where incorrect. These silent errors used to be fine but something failed in the latest deployment (2021-05-06) of Techhub and the `prepare-downloads or some other step of the publishing of the site failed silently leaving (at least) a couple of broken links.