### PR TITLE
Remove unused volumes in kafka service

### DIFF
--- a/docs-source/docs/modules/how-to/examples/shopping-cart-service-cassandra-java/docker-compose.yml
+++ b/docs-source/docs/modules/how-to/examples/shopping-cart-service-cassandra-java/docker-compose.yml
@@ -20,5 +20,3 @@ services:
     environment:
       KAFKA_ADVERTISED_HOST_NAME: localhost
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
-    volumes:
-      - /var/run/docker.sock:/var/run/docker.sock

--- a/docs-source/docs/modules/how-to/examples/shopping-cart-service-cassandra-scala/docker-compose.yml
+++ b/docs-source/docs/modules/how-to/examples/shopping-cart-service-cassandra-scala/docker-compose.yml
@@ -20,5 +20,3 @@ services:
     environment:
       KAFKA_ADVERTISED_HOST_NAME: localhost
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
-    volumes:
-      - /var/run/docker.sock:/var/run/docker.sock

--- a/docs-source/docs/modules/microservices-tutorial/examples/00-shopping-analytics-service-java/docker-compose.yml
+++ b/docs-source/docs/modules/microservices-tutorial/examples/00-shopping-analytics-service-java/docker-compose.yml
@@ -33,8 +33,6 @@ services:
     environment:
       KAFKA_ADVERTISED_HOST_NAME: localhost
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
-    volumes:
-      - /var/run/docker.sock:/var/run/docker.sock
 
   kafka-consumer:
     image: wurstmeister/kafka:2.13-2.7.0

--- a/docs-source/docs/modules/microservices-tutorial/examples/00-shopping-analytics-service-scala/docker-compose.yml
+++ b/docs-source/docs/modules/microservices-tutorial/examples/00-shopping-analytics-service-scala/docker-compose.yml
@@ -33,8 +33,6 @@ services:
     environment:
       KAFKA_ADVERTISED_HOST_NAME: localhost
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
-    volumes:
-      - /var/run/docker.sock:/var/run/docker.sock
 
   kafka-consumer:
     image: wurstmeister/kafka:2.13-2.7.0

--- a/docs-source/docs/modules/microservices-tutorial/examples/00-shopping-cart-service-java/docker-compose.yml
+++ b/docs-source/docs/modules/microservices-tutorial/examples/00-shopping-cart-service-java/docker-compose.yml
@@ -33,8 +33,6 @@ services:
     environment:
       KAFKA_ADVERTISED_HOST_NAME: localhost
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
-    volumes:
-      - /var/run/docker.sock:/var/run/docker.sock
 
   kafka-consumer:
     image: wurstmeister/kafka:2.13-2.7.0

--- a/docs-source/docs/modules/microservices-tutorial/examples/00-shopping-cart-service-scala/docker-compose.yml
+++ b/docs-source/docs/modules/microservices-tutorial/examples/00-shopping-cart-service-scala/docker-compose.yml
@@ -33,8 +33,6 @@ services:
     environment:
       KAFKA_ADVERTISED_HOST_NAME: localhost
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
-    volumes:
-      - /var/run/docker.sock:/var/run/docker.sock
 
   kafka-consumer:
     image: wurstmeister/kafka:2.13-2.7.0

--- a/docs-source/docs/modules/microservices-tutorial/examples/00-shopping-order-service-java/docker-compose.yml
+++ b/docs-source/docs/modules/microservices-tutorial/examples/00-shopping-order-service-java/docker-compose.yml
@@ -33,8 +33,6 @@ services:
     environment:
       KAFKA_ADVERTISED_HOST_NAME: localhost
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
-    volumes:
-      - /var/run/docker.sock:/var/run/docker.sock
 
   kafka-consumer:
     image: wurstmeister/kafka:2.13-2.7.0

--- a/docs-source/docs/modules/microservices-tutorial/examples/00-shopping-order-service-scala/docker-compose.yml
+++ b/docs-source/docs/modules/microservices-tutorial/examples/00-shopping-order-service-scala/docker-compose.yml
@@ -33,8 +33,6 @@ services:
     environment:
       KAFKA_ADVERTISED_HOST_NAME: localhost
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
-    volumes:
-      - /var/run/docker.sock:/var/run/docker.sock
 
   kafka-consumer:
     image: wurstmeister/kafka:2.13-2.7.0

--- a/docs-source/docs/modules/microservices-tutorial/examples/01-shopping-cart-service-java/docker-compose.yml
+++ b/docs-source/docs/modules/microservices-tutorial/examples/01-shopping-cart-service-java/docker-compose.yml
@@ -33,8 +33,6 @@ services:
     environment:
       KAFKA_ADVERTISED_HOST_NAME: localhost
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
-    volumes:
-      - /var/run/docker.sock:/var/run/docker.sock
 
   kafka-consumer:
     image: wurstmeister/kafka:2.13-2.7.0

--- a/docs-source/docs/modules/microservices-tutorial/examples/01-shopping-cart-service-scala/docker-compose.yml
+++ b/docs-source/docs/modules/microservices-tutorial/examples/01-shopping-cart-service-scala/docker-compose.yml
@@ -33,8 +33,6 @@ services:
     environment:
       KAFKA_ADVERTISED_HOST_NAME: localhost
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
-    volumes:
-      - /var/run/docker.sock:/var/run/docker.sock
 
   kafka-consumer:
     image: wurstmeister/kafka:2.13-2.7.0

--- a/docs-source/docs/modules/microservices-tutorial/examples/02-shopping-cart-service-java/docker-compose.yml
+++ b/docs-source/docs/modules/microservices-tutorial/examples/02-shopping-cart-service-java/docker-compose.yml
@@ -33,8 +33,6 @@ services:
     environment:
       KAFKA_ADVERTISED_HOST_NAME: localhost
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
-    volumes:
-      - /var/run/docker.sock:/var/run/docker.sock
 
   kafka-consumer:
     image: wurstmeister/kafka:2.13-2.7.0

--- a/docs-source/docs/modules/microservices-tutorial/examples/02-shopping-cart-service-scala/docker-compose.yml
+++ b/docs-source/docs/modules/microservices-tutorial/examples/02-shopping-cart-service-scala/docker-compose.yml
@@ -33,8 +33,6 @@ services:
     environment:
       KAFKA_ADVERTISED_HOST_NAME: localhost
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
-    volumes:
-      - /var/run/docker.sock:/var/run/docker.sock
 
   kafka-consumer:
     image: wurstmeister/kafka:2.13-2.7.0

--- a/docs-source/docs/modules/microservices-tutorial/examples/03-shopping-cart-service-java/docker-compose.yml
+++ b/docs-source/docs/modules/microservices-tutorial/examples/03-shopping-cart-service-java/docker-compose.yml
@@ -33,8 +33,6 @@ services:
     environment:
       KAFKA_ADVERTISED_HOST_NAME: localhost
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
-    volumes:
-      - /var/run/docker.sock:/var/run/docker.sock
 
   kafka-consumer:
     image: wurstmeister/kafka:2.13-2.7.0

--- a/docs-source/docs/modules/microservices-tutorial/examples/03-shopping-cart-service-scala/docker-compose.yml
+++ b/docs-source/docs/modules/microservices-tutorial/examples/03-shopping-cart-service-scala/docker-compose.yml
@@ -33,8 +33,6 @@ services:
     environment:
       KAFKA_ADVERTISED_HOST_NAME: localhost
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
-    volumes:
-      - /var/run/docker.sock:/var/run/docker.sock
 
   kafka-consumer:
     image: wurstmeister/kafka:2.13-2.7.0

--- a/docs-source/docs/modules/microservices-tutorial/examples/04-shopping-cart-service-java/docker-compose.yml
+++ b/docs-source/docs/modules/microservices-tutorial/examples/04-shopping-cart-service-java/docker-compose.yml
@@ -33,8 +33,6 @@ services:
     environment:
       KAFKA_ADVERTISED_HOST_NAME: localhost
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
-    volumes:
-      - /var/run/docker.sock:/var/run/docker.sock
 
   kafka-consumer:
     image: wurstmeister/kafka:2.13-2.7.0

--- a/docs-source/docs/modules/microservices-tutorial/examples/04-shopping-cart-service-scala/docker-compose.yml
+++ b/docs-source/docs/modules/microservices-tutorial/examples/04-shopping-cart-service-scala/docker-compose.yml
@@ -33,8 +33,6 @@ services:
     environment:
       KAFKA_ADVERTISED_HOST_NAME: localhost
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
-    volumes:
-      - /var/run/docker.sock:/var/run/docker.sock
 
   kafka-consumer:
     image: wurstmeister/kafka:2.13-2.7.0

--- a/docs-source/docs/modules/microservices-tutorial/examples/05-shopping-cart-service-java/docker-compose.yml
+++ b/docs-source/docs/modules/microservices-tutorial/examples/05-shopping-cart-service-java/docker-compose.yml
@@ -33,8 +33,6 @@ services:
     environment:
       KAFKA_ADVERTISED_HOST_NAME: localhost
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
-    volumes:
-      - /var/run/docker.sock:/var/run/docker.sock
 
   kafka-consumer:
     image: wurstmeister/kafka:2.13-2.7.0

--- a/docs-source/docs/modules/microservices-tutorial/examples/05-shopping-cart-service-scala/docker-compose.yml
+++ b/docs-source/docs/modules/microservices-tutorial/examples/05-shopping-cart-service-scala/docker-compose.yml
@@ -33,8 +33,6 @@ services:
     environment:
       KAFKA_ADVERTISED_HOST_NAME: localhost
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
-    volumes:
-      - /var/run/docker.sock:/var/run/docker.sock
 
   kafka-consumer:
     image: wurstmeister/kafka:2.13-2.7.0

--- a/docs-source/docs/modules/microservices-tutorial/examples/shopping-analytics-service-java/docker-compose.yml
+++ b/docs-source/docs/modules/microservices-tutorial/examples/shopping-analytics-service-java/docker-compose.yml
@@ -33,8 +33,6 @@ services:
     environment:
       KAFKA_ADVERTISED_HOST_NAME: localhost
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
-    volumes:
-      - /var/run/docker.sock:/var/run/docker.sock
 
   kafka-consumer:
     image: wurstmeister/kafka:2.13-2.7.0

--- a/docs-source/docs/modules/microservices-tutorial/examples/shopping-analytics-service-scala/docker-compose.yml
+++ b/docs-source/docs/modules/microservices-tutorial/examples/shopping-analytics-service-scala/docker-compose.yml
@@ -33,8 +33,6 @@ services:
     environment:
       KAFKA_ADVERTISED_HOST_NAME: localhost
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
-    volumes:
-      - /var/run/docker.sock:/var/run/docker.sock
 
   kafka-consumer:
     image: wurstmeister/kafka:2.13-2.7.0

--- a/docs-source/docs/modules/microservices-tutorial/examples/shopping-cart-service-java/docker-compose.yml
+++ b/docs-source/docs/modules/microservices-tutorial/examples/shopping-cart-service-java/docker-compose.yml
@@ -33,8 +33,6 @@ services:
     environment:
       KAFKA_ADVERTISED_HOST_NAME: localhost
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
-    volumes:
-      - /var/run/docker.sock:/var/run/docker.sock
 
   kafka-consumer:
     image: wurstmeister/kafka:2.13-2.7.0

--- a/docs-source/docs/modules/microservices-tutorial/examples/shopping-cart-service-scala/docker-compose.yml
+++ b/docs-source/docs/modules/microservices-tutorial/examples/shopping-cart-service-scala/docker-compose.yml
@@ -33,8 +33,6 @@ services:
     environment:
       KAFKA_ADVERTISED_HOST_NAME: localhost
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
-    volumes:
-      - /var/run/docker.sock:/var/run/docker.sock
 
   kafka-consumer:
     image: wurstmeister/kafka:2.13-2.7.0

--- a/docs-source/docs/modules/microservices-tutorial/examples/shopping-order-service-java/docker-compose.yml
+++ b/docs-source/docs/modules/microservices-tutorial/examples/shopping-order-service-java/docker-compose.yml
@@ -33,8 +33,6 @@ services:
     environment:
       KAFKA_ADVERTISED_HOST_NAME: localhost
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
-    volumes:
-      - /var/run/docker.sock:/var/run/docker.sock
 
   kafka-consumer:
     image: wurstmeister/kafka:2.13-2.7.0

--- a/docs-source/docs/modules/microservices-tutorial/examples/shopping-order-service-scala/docker-compose.yml
+++ b/docs-source/docs/modules/microservices-tutorial/examples/shopping-order-service-scala/docker-compose.yml
@@ -33,8 +33,6 @@ services:
     environment:
       KAFKA_ADVERTISED_HOST_NAME: localhost
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
-    volumes:
-      - /var/run/docker.sock:/var/run/docker.sock
 
   kafka-consumer:
     image: wurstmeister/kafka:2.13-2.7.0


### PR DESCRIPTION
Looks like these mappings were copied from an [example](https://raw.githubusercontent.com/wurstmeister/kafka-docker/master/docker-compose.yml). 
But I think it's not needed really. 