### PR TITLE
Fix wrong create_user_tables.sql reference

### DIFF
--- a/docs-source/docs/modules/microservices-tutorial/pages/projection-query.adoc
+++ b/docs-source/docs/modules/microservices-tutorial/pages/projection-query.adoc
@@ -358,9 +358,16 @@ docker-compose up -d
 
 . Create the item popularity table by creating a `ddl-scripts/create_user_tables.sql` file and adding the SQL statement below.
 +
+[.group-java]
 [source,sql,indent=0]
 ----
 include::example$04-shopping-cart-service-java/ddl-scripts/create_user_tables.sql[]
+----
+
+[.group-scala]
+[source,sql,indent=0]
+----
+include::example$04-shopping-cart-service-scala/ddl-scripts/create_user_tables.sql[]
 ----
 
 . Load the file into Postgres:


### PR DESCRIPTION
The scala solution does not have the version column in its data access.

Issue #604 was closed, but mentions the same issue.


