### PR TITLE
Clarify instructions

### DIFF
--- a/docs-source/docs/modules/deployment/pages/troubleshooting.adoc
+++ b/docs-source/docs/modules/deployment/pages/troubleshooting.adoc
@@ -105,6 +105,8 @@ They are similar to application logging, but are more coarse grained. A single e
 |The reconciliation of a Microservice has failed.
 |===
 
+For clarification, reconciliation is the process of ensuring that the data sets across multiple services are in agreement.
+
 === Viewing Events
 
 An operator event references the Pod of the operator and will appear alongside other Pod events in the `Events` summary table in a `kubectl describe pod` command.

--- a/docs-source/docs/modules/microservices-tutorial/pages/complete-entity.adoc
+++ b/docs-source/docs/modules/microservices-tutorial/pages/complete-entity.adoc
@@ -281,7 +281,7 @@ mvn test
 == Add new operations to the service descriptor
 
 
-Let's add corresponding operation definitions in `ShoppingCartService.proto`:
+In the existing `ShoppingCartService.proto` add corresponding operation definitions in the form of the two rpc calls listed below:
 
 .src/main/protobuf/ShoppingCartService.proto
 [source,protobuf]


### PR DESCRIPTION
Clarify instructions
per Part V - Add new operations to the service descriptor - instructions are unclear. #537

<!--
  Are there any relevant issues / PRs / mailing lists discussions?
  Please reference them here - but don't use `fixes` notation.
-->
References #xxxx
