### PR TITLE
Ignore some VSCode-related files

### DIFF
--- a/docs-source/docs/modules/microservices-tutorial/examples/00-shopping-analytics-service-java/.gitignore
+++ b/docs-source/docs/modules/microservices-tutorial/examples/00-shopping-analytics-service-java/.gitignore
@@ -9,3 +9,9 @@ target/
 *.iml
 
 .DS_Store
+
+
+.metals
+.vscode
+project/bloop
+project/metals.sbt

--- a/docs-source/docs/modules/microservices-tutorial/examples/00-shopping-analytics-service-scala/.gitignore
+++ b/docs-source/docs/modules/microservices-tutorial/examples/00-shopping-analytics-service-scala/.gitignore
@@ -9,3 +9,9 @@ target/
 *.iml
 
 .DS_Store
+
+
+.metals
+.vscode
+project/bloop
+project/metals.sbt

--- a/docs-source/docs/modules/microservices-tutorial/examples/00-shopping-cart-service-java/.gitignore
+++ b/docs-source/docs/modules/microservices-tutorial/examples/00-shopping-cart-service-java/.gitignore
@@ -8,3 +8,9 @@ target/
 *.iml
 
 .DS_Store
+
+
+.metals
+.vscode
+project/bloop
+project/metals.sbt

--- a/docs-source/docs/modules/microservices-tutorial/examples/00-shopping-cart-service-scala/.gitignore
+++ b/docs-source/docs/modules/microservices-tutorial/examples/00-shopping-cart-service-scala/.gitignore
@@ -9,3 +9,9 @@ target/
 *.iml
 
 .DS_Store
+
+
+.metals
+.vscode
+project/bloop
+project/metals.sbt

--- a/docs-source/docs/modules/microservices-tutorial/examples/00-shopping-order-service-java/.gitignore
+++ b/docs-source/docs/modules/microservices-tutorial/examples/00-shopping-order-service-java/.gitignore
@@ -9,3 +9,9 @@ target/
 *.iml
 
 .DS_Store
+
+
+.metals
+.vscode
+project/bloop
+project/metals.sbt

--- a/docs-source/docs/modules/microservices-tutorial/examples/00-shopping-order-service-scala/.gitignore
+++ b/docs-source/docs/modules/microservices-tutorial/examples/00-shopping-order-service-scala/.gitignore
@@ -9,3 +9,9 @@ target/
 *.iml
 
 .DS_Store
+
+
+.metals
+.vscode
+project/bloop
+project/metals.sbt

--- a/docs-source/docs/modules/microservices-tutorial/examples/01-shopping-cart-service-java/.gitignore
+++ b/docs-source/docs/modules/microservices-tutorial/examples/01-shopping-cart-service-java/.gitignore
@@ -9,3 +9,9 @@ target/
 *.iml
 
 .DS_Store
+
+
+.metals
+.vscode
+project/bloop
+project/metals.sbt

--- a/docs-source/docs/modules/microservices-tutorial/examples/01-shopping-cart-service-scala/.gitignore
+++ b/docs-source/docs/modules/microservices-tutorial/examples/01-shopping-cart-service-scala/.gitignore
@@ -9,3 +9,9 @@ target/
 *.iml
 
 .DS_Store
+
+
+.metals
+.vscode
+project/bloop
+project/metals.sbt

--- a/docs-source/docs/modules/microservices-tutorial/examples/02-shopping-cart-service-java/.gitignore
+++ b/docs-source/docs/modules/microservices-tutorial/examples/02-shopping-cart-service-java/.gitignore
@@ -9,3 +9,9 @@ target/
 *.iml
 
 .DS_Store
+
+
+.metals
+.vscode
+project/bloop
+project/metals.sbt

--- a/docs-source/docs/modules/microservices-tutorial/examples/02-shopping-cart-service-scala/.gitignore
+++ b/docs-source/docs/modules/microservices-tutorial/examples/02-shopping-cart-service-scala/.gitignore
@@ -9,3 +9,9 @@ target/
 *.iml
 
 .DS_Store
+
+
+.metals
+.vscode
+project/bloop
+project/metals.sbt

--- a/docs-source/docs/modules/microservices-tutorial/examples/03-shopping-cart-service-java/.gitignore
+++ b/docs-source/docs/modules/microservices-tutorial/examples/03-shopping-cart-service-java/.gitignore
@@ -9,3 +9,9 @@ target/
 *.iml
 
 .DS_Store
+
+
+.metals
+.vscode
+project/bloop
+project/metals.sbt

--- a/docs-source/docs/modules/microservices-tutorial/examples/03-shopping-cart-service-scala/.gitignore
+++ b/docs-source/docs/modules/microservices-tutorial/examples/03-shopping-cart-service-scala/.gitignore
@@ -9,3 +9,9 @@ target/
 *.iml
 
 .DS_Store
+
+
+.metals
+.vscode
+project/bloop
+project/metals.sbt

--- a/docs-source/docs/modules/microservices-tutorial/examples/04-shopping-cart-service-java/.gitignore
+++ b/docs-source/docs/modules/microservices-tutorial/examples/04-shopping-cart-service-java/.gitignore
@@ -9,3 +9,9 @@ target/
 *.iml
 
 .DS_Store
+
+
+.metals
+.vscode
+project/bloop
+project/metals.sbt

--- a/docs-source/docs/modules/microservices-tutorial/examples/04-shopping-cart-service-scala/.gitignore
+++ b/docs-source/docs/modules/microservices-tutorial/examples/04-shopping-cart-service-scala/.gitignore
@@ -9,3 +9,9 @@ target/
 *.iml
 
 .DS_Store
+
+
+.metals
+.vscode
+project/bloop
+project/metals.sbt

--- a/docs-source/docs/modules/microservices-tutorial/examples/05-shopping-cart-service-java/.gitignore
+++ b/docs-source/docs/modules/microservices-tutorial/examples/05-shopping-cart-service-java/.gitignore
@@ -9,3 +9,9 @@ target/
 *.iml
 
 .DS_Store
+
+
+.metals
+.vscode
+project/bloop
+project/metals.sbt

--- a/docs-source/docs/modules/microservices-tutorial/examples/05-shopping-cart-service-scala/.gitignore
+++ b/docs-source/docs/modules/microservices-tutorial/examples/05-shopping-cart-service-scala/.gitignore
@@ -9,3 +9,9 @@ target/
 *.iml
 
 .DS_Store
+
+
+.metals
+.vscode
+project/bloop
+project/metals.sbt

--- a/docs-source/docs/modules/microservices-tutorial/examples/shopping-analytics-service-java/.gitignore
+++ b/docs-source/docs/modules/microservices-tutorial/examples/shopping-analytics-service-java/.gitignore
@@ -9,3 +9,9 @@ target/
 *.iml
 
 .DS_Store
+
+
+.metals
+.vscode
+project/bloop
+project/metals.sbt

--- a/docs-source/docs/modules/microservices-tutorial/examples/shopping-analytics-service-scala/.gitignore
+++ b/docs-source/docs/modules/microservices-tutorial/examples/shopping-analytics-service-scala/.gitignore
@@ -9,3 +9,9 @@ target/
 *.iml
 
 .DS_Store
+
+
+.metals
+.vscode
+project/bloop
+project/metals.sbt

--- a/docs-source/docs/modules/microservices-tutorial/examples/shopping-cart-service-java/.gitignore
+++ b/docs-source/docs/modules/microservices-tutorial/examples/shopping-cart-service-java/.gitignore
@@ -9,3 +9,9 @@ target/
 *.iml
 
 .DS_Store
+
+
+.metals
+.vscode
+project/bloop
+project/metals.sbt

--- a/docs-source/docs/modules/microservices-tutorial/examples/shopping-cart-service-scala/.gitignore
+++ b/docs-source/docs/modules/microservices-tutorial/examples/shopping-cart-service-scala/.gitignore
@@ -9,3 +9,9 @@ target/
 *.iml
 
 .DS_Store
+
+
+.metals
+.vscode
+project/bloop
+project/metals.sbt

--- a/docs-source/docs/modules/microservices-tutorial/examples/shopping-order-service-java/.gitignore
+++ b/docs-source/docs/modules/microservices-tutorial/examples/shopping-order-service-java/.gitignore
@@ -9,3 +9,9 @@ target/
 *.iml
 
 .DS_Store
+
+
+.metals
+.vscode
+project/bloop
+project/metals.sbt

--- a/docs-source/docs/modules/microservices-tutorial/examples/shopping-order-service-scala/.gitignore
+++ b/docs-source/docs/modules/microservices-tutorial/examples/shopping-order-service-scala/.gitignore
@@ -9,3 +9,9 @@ target/
 *.iml
 
 .DS_Store
+
+
+.metals
+.vscode
+project/bloop
+project/metals.sbt


### PR DESCRIPTION
In general, it's better to ignore these folders and files globally but new users are likely to not have this global ignores.

The same way we already ignore `target`, `.idea` and `.bsp` we may ignore other VSCode and bloop/metals related files.