### PR TITLE
Wait for Cassandra server to start before running the tests

### DIFF
--- a/docs-source/docs/modules/how-to/examples/shopping-cart-service-cassandra-java/docker-compose.yml
+++ b/docs-source/docs/modules/how-to/examples/shopping-cart-service-cassandra-java/docker-compose.yml
@@ -1,9 +1,23 @@
 version: '2.2'
 services:
-  cassandra:
+  cassandra-service:
     image: cassandra:latest
     ports:
       - "9042:9042"
+    healthcheck:
+      test: ["CMD", "cqlsh", "-e", "describe keyspaces"]
+      interval: 5s
+      timeout: 5s
+      retries: 60
+  # This exists to force the condition of having the Cassandra service is up before starting the tests.
+  # The healthcheck above is not enough because it does not provide a condition to wait for the service
+  # to be up. And this is simpler than installing cqlsh and using it to check the service status on the
+  # CI server.
+  cassandra:
+    image: alpine:latest
+    depends_on:
+      cassandra-service:
+        condition: service_healthy
 
 # See dockerhub for different versions of kafka and zookeeper
 # https://hub.docker.com/r/wurstmeister/kafka/

--- a/docs-source/docs/modules/how-to/examples/shopping-cart-service-cassandra-scala/docker-compose.yml
+++ b/docs-source/docs/modules/how-to/examples/shopping-cart-service-cassandra-scala/docker-compose.yml
@@ -1,9 +1,23 @@
 version: '2.2'
 services:
-  cassandra:
+  cassandra-service:
     image: cassandra:latest
     ports:
       - "9042:9042"
+    healthcheck:
+      test: ["CMD", "cqlsh", "-e", "describe keyspaces"]
+      interval: 5s
+      timeout: 5s
+      retries: 60
+  # This exists to force the condition of having the Cassandra service is up before starting the tests.
+  # The healthcheck above is not enough because it does not provide a condition to wait for the service
+  # to be up. And this is simpler than installing cqlsh and using it to check the service status on the
+  # CI server.
+  cassandra:
+    image: alpine:latest
+    depends_on:
+      cassandra-service:
+        condition: service_healthy
 
 # See dockerhub for different versions of kafka and zookeeper
 # https://hub.docker.com/r/wurstmeister/kafka/


### PR DESCRIPTION
The latest version of Cassandra docker image uses Cassandra 4. This version takes longer
to start the service, possibly due to this issue:

https://issues.apache.org/jira/browse/CASSANDRA-15850

That is causing some builds to fail since the Cassandra server may no be up when the
tests start. The fix then is to have a healthcheck on docker compose and only run
the tests after the Cassandra server is healthy.
