### PR TITLE
Create akka_projection_management table

### DIFF
--- a/docs-source/docs/modules/how-to/examples/cleanup-dependencies-project/build.sbt
+++ b/docs-source/docs/modules/how-to/examples/cleanup-dependencies-project/build.sbt
@@ -2,9 +2,7 @@ name := "cleanup-dependencies-project"
 
 organization := "com.lightbend.akka.samples"
 organizationHomepage := Some(url("https://akka.io"))
-licenses := Seq(
-  ("CC0", url("https://creativecommons.org/publicdomain/zero/1.0"))
-)
+licenses := Seq(("CC0", url("https://creativecommons.org/publicdomain/zero/1.0")))
 
 scalaVersion := "2.13.5"
 
@@ -14,8 +12,7 @@ Compile / scalacOptions ++= Seq(
   "-feature",
   "-unchecked",
   "-Xlog-reflective-calls",
-  "-Xlint"
-)
+  "-Xlint")
 Compile / javacOptions ++= Seq("-Xlint:unchecked", "-Xlint:deprecation")
 
 Test / parallelExecution := false
@@ -39,7 +36,7 @@ val AkkaPersistenceJdbcVersion = "5.0.0"
 val AlpakkaKafkaVersion = "2.0.7"
 // end::remove-alpakka-kafka-version[]
 // tag::remove-akka-projection-version[]
-val AkkaProjectionVersion = "1.1.0"
+val AkkaProjectionVersion = "1.2.2"
 // end::remove-akka-projection-version[]
 
 // tag::remove-grpc-plugin[]
@@ -100,5 +97,4 @@ libraryDependencies ++= Seq(
   "com.typesafe.akka" %% "akka-actor-testkit-typed" % AkkaVersion % Test,
   "com.typesafe.akka" %% "akka-persistence-testkit" % AkkaVersion % Test,
   "com.typesafe.akka" %% "akka-stream-testkit" % AkkaVersion % Test,
-  "org.scalatest" %% "scalatest" % "3.1.2" % Test
-)
+  "org.scalatest" %% "scalatest" % "3.1.2" % Test)

--- a/docs-source/docs/modules/how-to/examples/shopping-cart-service-cassandra-java/ddl-scripts/create_tables.cql
+++ b/docs-source/docs/modules/how-to/examples/shopping-cart-service-cassandra-java/ddl-scripts/create_tables.cql
@@ -86,3 +86,11 @@ CREATE TABLE IF NOT EXISTS offset_store (
   manifest text,
   last_updated timestamp,
   PRIMARY KEY ((projection_name, partition), projection_key));
+
+CREATE TABLE IF NOT EXISTS projection_management (
+  projection_name text,
+  partition int,
+  projection_key text,
+  paused boolean,
+  last_updated timestamp,
+  PRIMARY KEY ((projection_name, partition), projection_key));

--- a/docs-source/docs/modules/how-to/examples/shopping-cart-service-cassandra-scala/build.sbt
+++ b/docs-source/docs/modules/how-to/examples/shopping-cart-service-cassandra-scala/build.sbt
@@ -12,8 +12,7 @@ Compile / scalacOptions ++= Seq(
   "-feature",
   "-unchecked",
   "-Xlog-reflective-calls",
-  "-Xlint"
-)
+  "-Xlint")
 Compile / javacOptions ++= Seq("-Xlint:unchecked", "-Xlint:deprecation")
 
 Test / parallelExecution := false
@@ -31,7 +30,7 @@ val AkkaPersistenceCassandraVersion = "1.0.5"
 
 // end::akka-persistence-cassandra[]
 val AlpakkaKafkaVersion = "2.0.7"
-val AkkaProjectionVersion = "1.1.0"
+val AkkaProjectionVersion = "1.2.2"
 
 enablePlugins(AkkaGrpcPlugin)
 
@@ -50,7 +49,6 @@ libraryDependencies ++= Seq(
   "com.typesafe.akka" %% "akka-cluster-sharding-typed" % AkkaVersion,
   "com.typesafe.akka" %% "akka-actor-testkit-typed" % AkkaVersion % Test,
   "com.typesafe.akka" %% "akka-stream-testkit" % AkkaVersion % Test,
-
   // Akka Management powers Health Checks and Akka Cluster Bootstrapping
   "com.lightbend.akka.management" %% "akka-management" % AkkaManagementVersion,
   "com.typesafe.akka" %% "akka-http" % AkkaHttpVersion,
@@ -59,15 +57,12 @@ libraryDependencies ++= Seq(
   "com.lightbend.akka.management" %% "akka-management-cluster-bootstrap" % AkkaManagementVersion,
   "com.lightbend.akka.discovery" %% "akka-discovery-kubernetes-api" % AkkaManagementVersion,
   "com.typesafe.akka" %% "akka-discovery" % AkkaVersion,
-
   // Common dependencies for logging and testing
   "com.typesafe.akka" %% "akka-slf4j" % AkkaVersion,
   "ch.qos.logback" % "logback-classic" % "1.2.3",
   "org.scalatest" %% "scalatest" % "3.1.2" % Test,
-
   // 2. Using gRPC and/or protobuf
   "com.typesafe.akka" %% "akka-http2-support" % AkkaHttpVersion,
-
   // 3. Using Akka Persistence
   "com.typesafe.akka" %% "akka-persistence-typed" % AkkaVersion,
   "com.typesafe.akka" %% "akka-serialization-jackson" % AkkaVersion,
@@ -75,7 +70,6 @@ libraryDependencies ++= Seq(
   "com.typesafe.akka" %% "akka-persistence-cassandra" % AkkaPersistenceCassandraVersion,
   // end::akka-persistence-cassandra[]
   "com.typesafe.akka" %% "akka-persistence-testkit" % AkkaVersion % Test,
-
   // 4. Querying or projecting data from Akka Persistence
   "com.typesafe.akka" %% "akka-persistence-query" % AkkaVersion,
   "com.lightbend.akka" %% "akka-projection-eventsourced" % AkkaProjectionVersion,
@@ -83,7 +77,7 @@ libraryDependencies ++= Seq(
   "com.lightbend.akka" %% "akka-projection-cassandra" % AkkaProjectionVersion,
   // end::akka-projection-cassandra[]
   "com.typesafe.akka" %% "akka-stream-kafka" % AlpakkaKafkaVersion,
-  "com.lightbend.akka" %% "akka-projection-testkit" % AkkaProjectionVersion % Test,
+  "com.lightbend.akka" %% "akka-projection-testkit" % AkkaProjectionVersion % Test
   // tag::akka-persistence-cassandra[]
 )
 // end::akka-persistence-cassandra[]

--- a/docs-source/docs/modules/how-to/examples/shopping-cart-service-cassandra-scala/ddl-scripts/create_tables.cql
+++ b/docs-source/docs/modules/how-to/examples/shopping-cart-service-cassandra-scala/ddl-scripts/create_tables.cql
@@ -86,3 +86,11 @@ CREATE TABLE IF NOT EXISTS offset_store (
   manifest text,
   last_updated timestamp,
   PRIMARY KEY ((projection_name, partition), projection_key));
+
+CREATE TABLE IF NOT EXISTS projection_management (
+  projection_name text,
+  partition int,
+  projection_key text,
+  paused boolean,
+  last_updated timestamp,
+  PRIMARY KEY ((projection_name, partition), projection_key));

--- a/docs-source/docs/modules/how-to/examples/shopping-cart-service-scala/build.sbt
+++ b/docs-source/docs/modules/how-to/examples/shopping-cart-service-scala/build.sbt
@@ -12,8 +12,7 @@ Compile / scalacOptions ++= Seq(
   "-feature",
   "-unchecked",
   "-Xlog-reflective-calls",
-  "-Xlint"
-)
+  "-Xlint")
 Compile / javacOptions ++= Seq("-Xlint:unchecked", "-Xlint:deprecation")
 
 Test / parallelExecution := false
@@ -30,7 +29,7 @@ val AkkaManagementVersion = "1.0.10"
 // end::dependencies-for-healthchecks[]
 val AkkaPersistenceCassandraVersion = "1.0.5"
 val AlpakkaKafkaVersion = "2.0.7"
-val AkkaProjectionVersion = "1.1.0"
+val AkkaProjectionVersion = "1.2.2"
 
 enablePlugins(AkkaGrpcPlugin)
 
@@ -49,7 +48,6 @@ libraryDependencies ++= Seq(
   "com.typesafe.akka" %% "akka-cluster-sharding-typed" % AkkaVersion,
   "com.typesafe.akka" %% "akka-actor-testkit-typed" % AkkaVersion % Test,
   "com.typesafe.akka" %% "akka-stream-testkit" % AkkaVersion % Test,
-
   // Akka Management powers Health Checks and Akka Cluster Bootstrapping
   // tag::dependencies-for-healthchecks[]
   "com.lightbend.akka.management" %% "akka-management" % AkkaManagementVersion,
@@ -62,28 +60,23 @@ libraryDependencies ++= Seq(
   "com.lightbend.akka.management" %% "akka-management-cluster-bootstrap" % AkkaManagementVersion,
   "com.lightbend.akka.discovery" %% "akka-discovery-kubernetes-api" % AkkaManagementVersion,
   "com.typesafe.akka" %% "akka-discovery" % AkkaVersion,
-
   // Common dependencies for logging and testing
   "com.typesafe.akka" %% "akka-slf4j" % AkkaVersion,
   "ch.qos.logback" % "logback-classic" % "1.2.3",
   "org.scalatest" %% "scalatest" % "3.1.2" % Test,
-
   // 2. Using gRPC and/or protobuf
   "com.typesafe.akka" %% "akka-http2-support" % AkkaHttpVersion,
-
   // 3. Using Akka Persistence
   "com.typesafe.akka" %% "akka-persistence-typed" % AkkaVersion,
   "com.typesafe.akka" %% "akka-serialization-jackson" % AkkaVersion,
   "com.typesafe.akka" %% "akka-persistence-cassandra" % AkkaPersistenceCassandraVersion,
   "com.typesafe.akka" %% "akka-persistence-testkit" % AkkaVersion % Test,
-
   // 4. Querying or projecting data from Akka Persistence
   "com.typesafe.akka" %% "akka-persistence-query" % AkkaVersion,
   "com.lightbend.akka" %% "akka-projection-eventsourced" % AkkaProjectionVersion,
   "com.lightbend.akka" %% "akka-projection-cassandra" % AkkaProjectionVersion,
   "com.typesafe.akka" %% "akka-stream-kafka" % AlpakkaKafkaVersion,
   "com.lightbend.akka" %% "akka-projection-testkit" % AkkaProjectionVersion % Test,
-
   // 5. Kubernetes Lease (used by SBR)
   // tag::akka-sbr-kubernetes-lease[]
   "com.lightbend.akka.management" %% "akka-lease-kubernetes" % AkkaManagementVersion

--- a/docs-source/docs/modules/microservices-tutorial/examples/00-shopping-analytics-service-scala/build.sbt
+++ b/docs-source/docs/modules/microservices-tutorial/examples/00-shopping-analytics-service-scala/build.sbt
@@ -2,9 +2,7 @@ name := "shopping-analytics-service"
 
 organization := "com.lightbend.akka.samples"
 organizationHomepage := Some(url("https://akka.io"))
-licenses := Seq(
-  ("CC0", url("https://creativecommons.org/publicdomain/zero/1.0"))
-)
+licenses := Seq(("CC0", url("https://creativecommons.org/publicdomain/zero/1.0")))
 
 scalaVersion := "2.13.5"
 
@@ -14,8 +12,7 @@ Compile / scalacOptions ++= Seq(
   "-feature",
   "-unchecked",
   "-Xlog-reflective-calls",
-  "-Xlint"
-)
+  "-Xlint")
 Compile / javacOptions ++= Seq("-Xlint:unchecked", "-Xlint:deprecation")
 
 Test / parallelExecution := false
@@ -30,7 +27,7 @@ val AkkaHttpVersion = "10.2.4"
 val AkkaManagementVersion = "1.0.10"
 val AkkaPersistenceJdbcVersion = "5.0.0"
 val AlpakkaKafkaVersion = "2.0.7"
-val AkkaProjectionVersion = "1.1.0"
+val AkkaProjectionVersion = "1.2.2"
 val ScalikeJdbcVersion = "3.5.0"
 
 enablePlugins(AkkaGrpcPlugin)
@@ -75,5 +72,4 @@ libraryDependencies ++= Seq(
   "org.scalikejdbc" %% "scalikejdbc" % ScalikeJdbcVersion,
   "org.scalikejdbc" %% "scalikejdbc-config" % ScalikeJdbcVersion,
   "com.typesafe.akka" %% "akka-stream-kafka" % AlpakkaKafkaVersion,
-  "com.lightbend.akka" %% "akka-projection-testkit" % AkkaProjectionVersion % Test
-)
+  "com.lightbend.akka" %% "akka-projection-testkit" % AkkaProjectionVersion % Test)

--- a/docs-source/docs/modules/microservices-tutorial/examples/00-shopping-cart-service-java/ddl-scripts/create_tables.sql
+++ b/docs-source/docs/modules/microservices-tutorial/examples/00-shopping-cart-service-java/ddl-scripts/create_tables.sql
@@ -65,4 +65,14 @@ CREATE TABLE IF NOT EXISTS public.akka_projection_offset_store (
     PRIMARY KEY(projection_name, projection_key)
     );
 
-CREATE INDEX IF NOT EXISTS projection_name_index ON akka_projection_offset_store (projection_name);
+CREATE INDEX IF NOT EXISTS projection_name_index ON public.akka_projection_offset_store (projection_name);
+
+--drop table if exists public.akka_projection_management;
+
+CREATE TABLE IF NOT EXISTS public.akka_projection_management (
+  projection_name VARCHAR(255) NOT NULL,
+  projection_key VARCHAR(255) NOT NULL,
+  paused BOOLEAN NOT NULL,
+  last_updated BIGINT NOT NULL,
+  PRIMARY KEY(projection_name, projection_key)
+);

--- a/docs-source/docs/modules/microservices-tutorial/examples/00-shopping-cart-service-scala/build.sbt
+++ b/docs-source/docs/modules/microservices-tutorial/examples/00-shopping-cart-service-scala/build.sbt
@@ -2,9 +2,7 @@ name := "shopping-cart-service"
 
 organization := "com.lightbend.akka.samples"
 organizationHomepage := Some(url("https://akka.io"))
-licenses := Seq(
-  ("CC0", url("https://creativecommons.org/publicdomain/zero/1.0"))
-)
+licenses := Seq(("CC0", url("https://creativecommons.org/publicdomain/zero/1.0")))
 
 scalaVersion := "2.13.5"
 
@@ -14,8 +12,7 @@ Compile / scalacOptions ++= Seq(
   "-feature",
   "-unchecked",
   "-Xlog-reflective-calls",
-  "-Xlint"
-)
+  "-Xlint")
 Compile / javacOptions ++= Seq("-Xlint:unchecked", "-Xlint:deprecation")
 
 Test / parallelExecution := false
@@ -30,7 +27,7 @@ val AkkaHttpVersion = "10.2.4"
 val AkkaManagementVersion = "1.0.10"
 val AkkaPersistenceJdbcVersion = "5.0.0"
 val AlpakkaKafkaVersion = "2.0.7"
-val AkkaProjectionVersion = "1.1.0"
+val AkkaProjectionVersion = "1.2.2"
 val ScalikeJdbcVersion = "3.5.0"
 
 enablePlugins(AkkaGrpcPlugin)
@@ -75,5 +72,4 @@ libraryDependencies ++= Seq(
   "org.scalikejdbc" %% "scalikejdbc" % ScalikeJdbcVersion,
   "org.scalikejdbc" %% "scalikejdbc-config" % ScalikeJdbcVersion,
   "com.typesafe.akka" %% "akka-stream-kafka" % AlpakkaKafkaVersion,
-  "com.lightbend.akka" %% "akka-projection-testkit" % AkkaProjectionVersion % Test
-)
+  "com.lightbend.akka" %% "akka-projection-testkit" % AkkaProjectionVersion % Test)

--- a/docs-source/docs/modules/microservices-tutorial/examples/00-shopping-cart-service-scala/ddl-scripts/create_tables.sql
+++ b/docs-source/docs/modules/microservices-tutorial/examples/00-shopping-cart-service-scala/ddl-scripts/create_tables.sql
@@ -53,9 +53,9 @@ CREATE TABLE IF NOT EXISTS public.snapshot (
   PRIMARY KEY(persistence_id, sequence_number)
 );
 
---drop table if exists public."AKKA_PROJECTION_OFFSET_STORE";
+--drop table if exists public.akka_projection_offset_store;
 
-CREATE TABLE IF NOT EXISTS akka_projection_offset_store (
+CREATE TABLE IF NOT EXISTS public.akka_projection_offset_store (
     projection_name VARCHAR(255) NOT NULL,
     projection_key VARCHAR(255) NOT NULL,
     current_offset VARCHAR(255) NOT NULL,
@@ -65,4 +65,14 @@ CREATE TABLE IF NOT EXISTS akka_projection_offset_store (
     PRIMARY KEY(projection_name, projection_key)
     );
 
-CREATE INDEX IF NOT EXISTS projection_name_index ON akka_projection_offset_store (projection_name);
+CREATE INDEX IF NOT EXISTS projection_name_index ON public.akka_projection_offset_store (projection_name);
+
+--drop table if exists public.akka_projection_management;
+
+CREATE TABLE IF NOT EXISTS public.akka_projection_management (
+  projection_name VARCHAR(255) NOT NULL,
+  projection_key VARCHAR(255) NOT NULL,
+  paused BOOLEAN NOT NULL,
+  last_updated BIGINT NOT NULL,
+  PRIMARY KEY(projection_name, projection_key)
+);

--- a/docs-source/docs/modules/microservices-tutorial/examples/00-shopping-order-service-java/ddl-scripts/create_tables.cql
+++ b/docs-source/docs/modules/microservices-tutorial/examples/00-shopping-order-service-java/ddl-scripts/create_tables.cql
@@ -86,3 +86,11 @@ CREATE TABLE IF NOT EXISTS offset_store (
   manifest text,
   last_updated timestamp,
   PRIMARY KEY ((projection_name, partition), projection_key));
+
+CREATE TABLE IF NOT EXISTS projection_management (
+  projection_name text,
+  partition int,
+  projection_key text,
+  paused boolean,
+  last_updated timestamp,
+  PRIMARY KEY ((projection_name, partition), projection_key));

--- a/docs-source/docs/modules/microservices-tutorial/examples/00-shopping-order-service-scala/build.sbt
+++ b/docs-source/docs/modules/microservices-tutorial/examples/00-shopping-order-service-scala/build.sbt
@@ -2,9 +2,7 @@ name := "shopping-order-service"
 
 organization := "com.lightbend.akka.samples"
 organizationHomepage := Some(url("https://akka.io"))
-licenses := Seq(
-  ("CC0", url("https://creativecommons.org/publicdomain/zero/1.0"))
-)
+licenses := Seq(("CC0", url("https://creativecommons.org/publicdomain/zero/1.0")))
 
 scalaVersion := "2.13.5"
 
@@ -14,8 +12,7 @@ Compile / scalacOptions ++= Seq(
   "-feature",
   "-unchecked",
   "-Xlog-reflective-calls",
-  "-Xlint"
-)
+  "-Xlint")
 Compile / javacOptions ++= Seq("-Xlint:unchecked", "-Xlint:deprecation")
 
 Test / parallelExecution := false
@@ -30,7 +27,7 @@ val AkkaHttpVersion = "10.2.4"
 val AkkaManagementVersion = "1.0.10"
 val AkkaPersistenceJdbcVersion = "5.0.0"
 val AlpakkaKafkaVersion = "2.0.7"
-val AkkaProjectionVersion = "1.1.0"
+val AkkaProjectionVersion = "1.2.2"
 val ScalikeJdbcVersion = "3.5.0"
 
 enablePlugins(AkkaGrpcPlugin)
@@ -75,5 +72,4 @@ libraryDependencies ++= Seq(
   "org.scalikejdbc" %% "scalikejdbc" % ScalikeJdbcVersion,
   "org.scalikejdbc" %% "scalikejdbc-config" % ScalikeJdbcVersion,
   "com.typesafe.akka" %% "akka-stream-kafka" % AlpakkaKafkaVersion,
-  "com.lightbend.akka" %% "akka-projection-testkit" % AkkaProjectionVersion % Test
-)
+  "com.lightbend.akka" %% "akka-projection-testkit" % AkkaProjectionVersion % Test)

--- a/docs-source/docs/modules/microservices-tutorial/examples/00-shopping-order-service-scala/ddl-scripts/create_tables.cql
+++ b/docs-source/docs/modules/microservices-tutorial/examples/00-shopping-order-service-scala/ddl-scripts/create_tables.cql
@@ -86,3 +86,11 @@ CREATE TABLE IF NOT EXISTS offset_store (
   manifest text,
   last_updated timestamp,
   PRIMARY KEY ((projection_name, partition), projection_key));
+
+CREATE TABLE IF NOT EXISTS projection_management (
+  projection_name text,
+  partition int,
+  projection_key text,
+  paused boolean,
+  last_updated timestamp,
+  PRIMARY KEY ((projection_name, partition), projection_key));

--- a/docs-source/docs/modules/microservices-tutorial/examples/01-shopping-cart-service-java/ddl-scripts/create_tables.sql
+++ b/docs-source/docs/modules/microservices-tutorial/examples/01-shopping-cart-service-java/ddl-scripts/create_tables.sql
@@ -65,4 +65,14 @@ CREATE TABLE IF NOT EXISTS public.akka_projection_offset_store (
     PRIMARY KEY(projection_name, projection_key)
     );
 
-CREATE INDEX IF NOT EXISTS projection_name_index ON akka_projection_offset_store (projection_name);
+CREATE INDEX IF NOT EXISTS projection_name_index ON public.akka_projection_offset_store (projection_name);
+
+--drop table if exists public.akka_projection_management;
+
+CREATE TABLE IF NOT EXISTS public.akka_projection_management (
+  projection_name VARCHAR(255) NOT NULL,
+  projection_key VARCHAR(255) NOT NULL,
+  paused BOOLEAN NOT NULL,
+  last_updated BIGINT NOT NULL,
+  PRIMARY KEY(projection_name, projection_key)
+);

--- a/docs-source/docs/modules/microservices-tutorial/examples/01-shopping-cart-service-scala/build.sbt
+++ b/docs-source/docs/modules/microservices-tutorial/examples/01-shopping-cart-service-scala/build.sbt
@@ -2,9 +2,7 @@ name := "shopping-cart-service"
 
 organization := "com.lightbend.akka.samples"
 organizationHomepage := Some(url("https://akka.io"))
-licenses := Seq(
-  ("CC0", url("https://creativecommons.org/publicdomain/zero/1.0"))
-)
+licenses := Seq(("CC0", url("https://creativecommons.org/publicdomain/zero/1.0")))
 
 scalaVersion := "2.13.5"
 
@@ -14,8 +12,7 @@ Compile / scalacOptions ++= Seq(
   "-feature",
   "-unchecked",
   "-Xlog-reflective-calls",
-  "-Xlint"
-)
+  "-Xlint")
 Compile / javacOptions ++= Seq("-Xlint:unchecked", "-Xlint:deprecation")
 
 Test / parallelExecution := false
@@ -30,7 +27,7 @@ val AkkaHttpVersion = "10.2.4"
 val AkkaManagementVersion = "1.0.10"
 val AkkaPersistenceJdbcVersion = "5.0.0"
 val AlpakkaKafkaVersion = "2.0.7"
-val AkkaProjectionVersion = "1.1.0"
+val AkkaProjectionVersion = "1.2.2"
 val ScalikeJdbcVersion = "3.5.0"
 
 enablePlugins(AkkaGrpcPlugin)
@@ -75,5 +72,4 @@ libraryDependencies ++= Seq(
   "org.scalikejdbc" %% "scalikejdbc" % ScalikeJdbcVersion,
   "org.scalikejdbc" %% "scalikejdbc-config" % ScalikeJdbcVersion,
   "com.typesafe.akka" %% "akka-stream-kafka" % AlpakkaKafkaVersion,
-  "com.lightbend.akka" %% "akka-projection-testkit" % AkkaProjectionVersion % Test
-)
+  "com.lightbend.akka" %% "akka-projection-testkit" % AkkaProjectionVersion % Test)

--- a/docs-source/docs/modules/microservices-tutorial/examples/01-shopping-cart-service-scala/ddl-scripts/create_tables.cql
+++ b/docs-source/docs/modules/microservices-tutorial/examples/01-shopping-cart-service-scala/ddl-scripts/create_tables.cql
@@ -86,3 +86,11 @@ CREATE TABLE IF NOT EXISTS offset_store (
   manifest text,
   last_updated timestamp,
   PRIMARY KEY ((projection_name, partition), projection_key));
+
+CREATE TABLE IF NOT EXISTS projection_management (
+  projection_name text,
+  partition int,
+  projection_key text,
+  paused boolean,
+  last_updated timestamp,
+  PRIMARY KEY ((projection_name, partition), projection_key));

--- a/docs-source/docs/modules/microservices-tutorial/examples/01-shopping-cart-service-scala/ddl-scripts/create_tables.sql
+++ b/docs-source/docs/modules/microservices-tutorial/examples/01-shopping-cart-service-scala/ddl-scripts/create_tables.sql
@@ -65,4 +65,14 @@ CREATE TABLE IF NOT EXISTS public.akka_projection_offset_store (
     PRIMARY KEY(projection_name, projection_key)
     );
 
-CREATE INDEX IF NOT EXISTS projection_name_index ON akka_projection_offset_store (projection_name);
+CREATE INDEX IF NOT EXISTS projection_name_index ON public.akka_projection_offset_store (projection_name);
+
+--drop table if exists public.akka_projection_management;
+
+CREATE TABLE IF NOT EXISTS public.akka_projection_management (
+  projection_name VARCHAR(255) NOT NULL,
+  projection_key VARCHAR(255) NOT NULL,
+  paused BOOLEAN NOT NULL,
+  last_updated BIGINT NOT NULL,
+  PRIMARY KEY(projection_name, projection_key)
+);

--- a/docs-source/docs/modules/microservices-tutorial/examples/02-shopping-cart-service-java/ddl-scripts/create_tables.sql
+++ b/docs-source/docs/modules/microservices-tutorial/examples/02-shopping-cart-service-java/ddl-scripts/create_tables.sql
@@ -65,4 +65,14 @@ CREATE TABLE IF NOT EXISTS public.akka_projection_offset_store (
     PRIMARY KEY(projection_name, projection_key)
     );
 
-CREATE INDEX IF NOT EXISTS projection_name_index ON akka_projection_offset_store (projection_name);
+CREATE INDEX IF NOT EXISTS projection_name_index ON public.akka_projection_offset_store (projection_name);
+
+--drop table if exists public.akka_projection_management;
+
+CREATE TABLE IF NOT EXISTS public.akka_projection_management (
+  projection_name VARCHAR(255) NOT NULL,
+  projection_key VARCHAR(255) NOT NULL,
+  paused BOOLEAN NOT NULL,
+  last_updated BIGINT NOT NULL,
+  PRIMARY KEY(projection_name, projection_key)
+);

--- a/docs-source/docs/modules/microservices-tutorial/examples/02-shopping-cart-service-scala/build.sbt
+++ b/docs-source/docs/modules/microservices-tutorial/examples/02-shopping-cart-service-scala/build.sbt
@@ -2,9 +2,7 @@ name := "shopping-cart-service"
 
 organization := "com.lightbend.akka.samples"
 organizationHomepage := Some(url("https://akka.io"))
-licenses := Seq(
-  ("CC0", url("https://creativecommons.org/publicdomain/zero/1.0"))
-)
+licenses := Seq(("CC0", url("https://creativecommons.org/publicdomain/zero/1.0")))
 
 scalaVersion := "2.13.5"
 
@@ -14,8 +12,7 @@ Compile / scalacOptions ++= Seq(
   "-feature",
   "-unchecked",
   "-Xlog-reflective-calls",
-  "-Xlint"
-)
+  "-Xlint")
 Compile / javacOptions ++= Seq("-Xlint:unchecked", "-Xlint:deprecation")
 
 Test / parallelExecution := false
@@ -30,7 +27,7 @@ val AkkaHttpVersion = "10.2.4"
 val AkkaManagementVersion = "1.0.10"
 val AkkaPersistenceJdbcVersion = "5.0.0"
 val AlpakkaKafkaVersion = "2.0.7"
-val AkkaProjectionVersion = "1.1.0"
+val AkkaProjectionVersion = "1.2.2"
 val ScalikeJdbcVersion = "3.5.0"
 
 enablePlugins(AkkaGrpcPlugin)
@@ -75,5 +72,4 @@ libraryDependencies ++= Seq(
   "org.scalikejdbc" %% "scalikejdbc" % ScalikeJdbcVersion,
   "org.scalikejdbc" %% "scalikejdbc-config" % ScalikeJdbcVersion,
   "com.typesafe.akka" %% "akka-stream-kafka" % AlpakkaKafkaVersion,
-  "com.lightbend.akka" %% "akka-projection-testkit" % AkkaProjectionVersion % Test
-)
+  "com.lightbend.akka" %% "akka-projection-testkit" % AkkaProjectionVersion % Test)

--- a/docs-source/docs/modules/microservices-tutorial/examples/02-shopping-cart-service-scala/ddl-scripts/create_tables.sql
+++ b/docs-source/docs/modules/microservices-tutorial/examples/02-shopping-cart-service-scala/ddl-scripts/create_tables.sql
@@ -65,4 +65,14 @@ CREATE TABLE IF NOT EXISTS public.akka_projection_offset_store (
     PRIMARY KEY(projection_name, projection_key)
     );
 
-CREATE INDEX IF NOT EXISTS projection_name_index ON akka_projection_offset_store (projection_name);
+CREATE INDEX IF NOT EXISTS projection_name_index ON public.akka_projection_offset_store (projection_name);
+
+--drop table if exists public.akka_projection_management;
+
+CREATE TABLE IF NOT EXISTS public.akka_projection_management (
+  projection_name VARCHAR(255) NOT NULL,
+  projection_key VARCHAR(255) NOT NULL,
+  paused BOOLEAN NOT NULL,
+  last_updated BIGINT NOT NULL,
+  PRIMARY KEY(projection_name, projection_key)
+);

--- a/docs-source/docs/modules/microservices-tutorial/examples/03-shopping-cart-service-java/ddl-scripts/create_tables.sql
+++ b/docs-source/docs/modules/microservices-tutorial/examples/03-shopping-cart-service-java/ddl-scripts/create_tables.sql
@@ -65,4 +65,14 @@ CREATE TABLE IF NOT EXISTS public.akka_projection_offset_store (
     PRIMARY KEY(projection_name, projection_key)
     );
 
-CREATE INDEX IF NOT EXISTS projection_name_index ON akka_projection_offset_store (projection_name);
+CREATE INDEX IF NOT EXISTS projection_name_index ON public.akka_projection_offset_store (projection_name);
+
+--drop table if exists public.akka_projection_management;
+
+CREATE TABLE IF NOT EXISTS public.akka_projection_management (
+  projection_name VARCHAR(255) NOT NULL,
+  projection_key VARCHAR(255) NOT NULL,
+  paused BOOLEAN NOT NULL,
+  last_updated BIGINT NOT NULL,
+  PRIMARY KEY(projection_name, projection_key)
+);

--- a/docs-source/docs/modules/microservices-tutorial/examples/03-shopping-cart-service-scala/build.sbt
+++ b/docs-source/docs/modules/microservices-tutorial/examples/03-shopping-cart-service-scala/build.sbt
@@ -2,9 +2,7 @@ name := "shopping-cart-service"
 
 organization := "com.lightbend.akka.samples"
 organizationHomepage := Some(url("https://akka.io"))
-licenses := Seq(
-  ("CC0", url("https://creativecommons.org/publicdomain/zero/1.0"))
-)
+licenses := Seq(("CC0", url("https://creativecommons.org/publicdomain/zero/1.0")))
 
 scalaVersion := "2.13.5"
 
@@ -14,8 +12,7 @@ Compile / scalacOptions ++= Seq(
   "-feature",
   "-unchecked",
   "-Xlog-reflective-calls",
-  "-Xlint"
-)
+  "-Xlint")
 Compile / javacOptions ++= Seq("-Xlint:unchecked", "-Xlint:deprecation")
 
 Test / parallelExecution := false
@@ -30,7 +27,7 @@ val AkkaHttpVersion = "10.2.4"
 val AkkaManagementVersion = "1.0.10"
 val AkkaPersistenceJdbcVersion = "5.0.0"
 val AlpakkaKafkaVersion = "2.0.7"
-val AkkaProjectionVersion = "1.1.0"
+val AkkaProjectionVersion = "1.2.2"
 val ScalikeJdbcVersion = "3.5.0"
 
 enablePlugins(AkkaGrpcPlugin)
@@ -75,5 +72,4 @@ libraryDependencies ++= Seq(
   "org.scalikejdbc" %% "scalikejdbc" % ScalikeJdbcVersion,
   "org.scalikejdbc" %% "scalikejdbc-config" % ScalikeJdbcVersion,
   "com.typesafe.akka" %% "akka-stream-kafka" % AlpakkaKafkaVersion,
-  "com.lightbend.akka" %% "akka-projection-testkit" % AkkaProjectionVersion % Test
-)
+  "com.lightbend.akka" %% "akka-projection-testkit" % AkkaProjectionVersion % Test)

--- a/docs-source/docs/modules/microservices-tutorial/examples/03-shopping-cart-service-scala/ddl-scripts/create_tables.sql
+++ b/docs-source/docs/modules/microservices-tutorial/examples/03-shopping-cart-service-scala/ddl-scripts/create_tables.sql
@@ -65,4 +65,14 @@ CREATE TABLE IF NOT EXISTS public.akka_projection_offset_store (
     PRIMARY KEY(projection_name, projection_key)
     );
 
-CREATE INDEX IF NOT EXISTS projection_name_index ON akka_projection_offset_store (projection_name);
+CREATE INDEX IF NOT EXISTS projection_name_index ON public.akka_projection_offset_store (projection_name);
+
+--drop table if exists public.akka_projection_management;
+
+CREATE TABLE IF NOT EXISTS public.akka_projection_management (
+  projection_name VARCHAR(255) NOT NULL,
+  projection_key VARCHAR(255) NOT NULL,
+  paused BOOLEAN NOT NULL,
+  last_updated BIGINT NOT NULL,
+  PRIMARY KEY(projection_name, projection_key)
+);

--- a/docs-source/docs/modules/microservices-tutorial/examples/04-shopping-cart-service-java/ddl-scripts/create_tables.sql
+++ b/docs-source/docs/modules/microservices-tutorial/examples/04-shopping-cart-service-java/ddl-scripts/create_tables.sql
@@ -65,4 +65,14 @@ CREATE TABLE IF NOT EXISTS public.akka_projection_offset_store (
     PRIMARY KEY(projection_name, projection_key)
     );
 
-CREATE INDEX IF NOT EXISTS projection_name_index ON akka_projection_offset_store (projection_name);
+CREATE INDEX IF NOT EXISTS projection_name_index ON public.akka_projection_offset_store (projection_name);
+
+--drop table if exists public.akka_projection_management;
+
+CREATE TABLE IF NOT EXISTS public.akka_projection_management (
+  projection_name VARCHAR(255) NOT NULL,
+  projection_key VARCHAR(255) NOT NULL,
+  paused BOOLEAN NOT NULL,
+  last_updated BIGINT NOT NULL,
+  PRIMARY KEY(projection_name, projection_key)
+);

--- a/docs-source/docs/modules/microservices-tutorial/examples/04-shopping-cart-service-scala/build.sbt
+++ b/docs-source/docs/modules/microservices-tutorial/examples/04-shopping-cart-service-scala/build.sbt
@@ -2,9 +2,7 @@ name := "shopping-cart-service"
 
 organization := "com.lightbend.akka.samples"
 organizationHomepage := Some(url("https://akka.io"))
-licenses := Seq(
-  ("CC0", url("https://creativecommons.org/publicdomain/zero/1.0"))
-)
+licenses := Seq(("CC0", url("https://creativecommons.org/publicdomain/zero/1.0")))
 
 scalaVersion := "2.13.5"
 
@@ -14,8 +12,7 @@ Compile / scalacOptions ++= Seq(
   "-feature",
   "-unchecked",
   "-Xlog-reflective-calls",
-  "-Xlint"
-)
+  "-Xlint")
 Compile / javacOptions ++= Seq("-Xlint:unchecked", "-Xlint:deprecation")
 
 Test / parallelExecution := false
@@ -30,7 +27,7 @@ val AkkaHttpVersion = "10.2.4"
 val AkkaManagementVersion = "1.0.10"
 val AkkaPersistenceJdbcVersion = "5.0.0"
 val AlpakkaKafkaVersion = "2.0.7"
-val AkkaProjectionVersion = "1.1.0"
+val AkkaProjectionVersion = "1.2.2"
 val ScalikeJdbcVersion = "3.5.0"
 
 enablePlugins(AkkaGrpcPlugin)
@@ -75,5 +72,4 @@ libraryDependencies ++= Seq(
   "org.scalikejdbc" %% "scalikejdbc" % ScalikeJdbcVersion,
   "org.scalikejdbc" %% "scalikejdbc-config" % ScalikeJdbcVersion,
   "com.typesafe.akka" %% "akka-stream-kafka" % AlpakkaKafkaVersion,
-  "com.lightbend.akka" %% "akka-projection-testkit" % AkkaProjectionVersion % Test
-)
+  "com.lightbend.akka" %% "akka-projection-testkit" % AkkaProjectionVersion % Test)

--- a/docs-source/docs/modules/microservices-tutorial/examples/04-shopping-cart-service-scala/ddl-scripts/create_tables.sql
+++ b/docs-source/docs/modules/microservices-tutorial/examples/04-shopping-cart-service-scala/ddl-scripts/create_tables.sql
@@ -65,4 +65,14 @@ CREATE TABLE IF NOT EXISTS public.akka_projection_offset_store (
     PRIMARY KEY(projection_name, projection_key)
     );
 
-CREATE INDEX IF NOT EXISTS projection_name_index ON akka_projection_offset_store (projection_name);
+CREATE INDEX IF NOT EXISTS projection_name_index ON public.akka_projection_offset_store (projection_name);
+
+--drop table if exists public.akka_projection_management;
+
+CREATE TABLE IF NOT EXISTS public.akka_projection_management (
+  projection_name VARCHAR(255) NOT NULL,
+  projection_key VARCHAR(255) NOT NULL,
+  paused BOOLEAN NOT NULL,
+  last_updated BIGINT NOT NULL,
+  PRIMARY KEY(projection_name, projection_key)
+);

--- a/docs-source/docs/modules/microservices-tutorial/examples/05-shopping-cart-service-java/ddl-scripts/create_tables.sql
+++ b/docs-source/docs/modules/microservices-tutorial/examples/05-shopping-cart-service-java/ddl-scripts/create_tables.sql
@@ -65,4 +65,14 @@ CREATE TABLE IF NOT EXISTS public.akka_projection_offset_store (
     PRIMARY KEY(projection_name, projection_key)
     );
 
-CREATE INDEX IF NOT EXISTS projection_name_index ON akka_projection_offset_store (projection_name);
+CREATE INDEX IF NOT EXISTS projection_name_index ON public.akka_projection_offset_store (projection_name);
+
+--drop table if exists public.akka_projection_management;
+
+CREATE TABLE IF NOT EXISTS public.akka_projection_management (
+  projection_name VARCHAR(255) NOT NULL,
+  projection_key VARCHAR(255) NOT NULL,
+  paused BOOLEAN NOT NULL,
+  last_updated BIGINT NOT NULL,
+  PRIMARY KEY(projection_name, projection_key)
+);

--- a/docs-source/docs/modules/microservices-tutorial/examples/05-shopping-cart-service-scala/build.sbt
+++ b/docs-source/docs/modules/microservices-tutorial/examples/05-shopping-cart-service-scala/build.sbt
@@ -2,9 +2,7 @@ name := "shopping-cart-service"
 
 organization := "com.lightbend.akka.samples"
 organizationHomepage := Some(url("https://akka.io"))
-licenses := Seq(
-  ("CC0", url("https://creativecommons.org/publicdomain/zero/1.0"))
-)
+licenses := Seq(("CC0", url("https://creativecommons.org/publicdomain/zero/1.0")))
 
 scalaVersion := "2.13.5"
 
@@ -14,8 +12,7 @@ Compile / scalacOptions ++= Seq(
   "-feature",
   "-unchecked",
   "-Xlog-reflective-calls",
-  "-Xlint"
-)
+  "-Xlint")
 Compile / javacOptions ++= Seq("-Xlint:unchecked", "-Xlint:deprecation")
 
 Test / parallelExecution := false
@@ -30,7 +27,7 @@ val AkkaHttpVersion = "10.2.4"
 val AkkaManagementVersion = "1.0.10"
 val AkkaPersistenceJdbcVersion = "5.0.0"
 val AlpakkaKafkaVersion = "2.0.7"
-val AkkaProjectionVersion = "1.1.0"
+val AkkaProjectionVersion = "1.2.2"
 val ScalikeJdbcVersion = "3.5.0"
 
 enablePlugins(AkkaGrpcPlugin)
@@ -75,5 +72,4 @@ libraryDependencies ++= Seq(
   "org.scalikejdbc" %% "scalikejdbc" % ScalikeJdbcVersion,
   "org.scalikejdbc" %% "scalikejdbc-config" % ScalikeJdbcVersion,
   "com.typesafe.akka" %% "akka-stream-kafka" % AlpakkaKafkaVersion,
-  "com.lightbend.akka" %% "akka-projection-testkit" % AkkaProjectionVersion % Test
-)
+  "com.lightbend.akka" %% "akka-projection-testkit" % AkkaProjectionVersion % Test)

--- a/docs-source/docs/modules/microservices-tutorial/examples/05-shopping-cart-service-scala/ddl-scripts/create_tables.sql
+++ b/docs-source/docs/modules/microservices-tutorial/examples/05-shopping-cart-service-scala/ddl-scripts/create_tables.sql
@@ -65,4 +65,14 @@ CREATE TABLE IF NOT EXISTS public.akka_projection_offset_store (
     PRIMARY KEY(projection_name, projection_key)
     );
 
-CREATE INDEX IF NOT EXISTS projection_name_index ON akka_projection_offset_store (projection_name);
+CREATE INDEX IF NOT EXISTS projection_name_index ON public.akka_projection_offset_store (projection_name);
+
+--drop table if exists public.akka_projection_management;
+
+CREATE TABLE IF NOT EXISTS public.akka_projection_management (
+  projection_name VARCHAR(255) NOT NULL,
+  projection_key VARCHAR(255) NOT NULL,
+  paused BOOLEAN NOT NULL,
+  last_updated BIGINT NOT NULL,
+  PRIMARY KEY(projection_name, projection_key)
+);

--- a/docs-source/docs/modules/microservices-tutorial/examples/shopping-analytics-service-scala/build.sbt
+++ b/docs-source/docs/modules/microservices-tutorial/examples/shopping-analytics-service-scala/build.sbt
@@ -2,9 +2,7 @@ name := "shopping-analytics-service"
 
 organization := "com.lightbend.akka.samples"
 organizationHomepage := Some(url("https://akka.io"))
-licenses := Seq(
-  ("CC0", url("https://creativecommons.org/publicdomain/zero/1.0"))
-)
+licenses := Seq(("CC0", url("https://creativecommons.org/publicdomain/zero/1.0")))
 
 scalaVersion := "2.13.5"
 
@@ -14,8 +12,7 @@ Compile / scalacOptions ++= Seq(
   "-feature",
   "-unchecked",
   "-Xlog-reflective-calls",
-  "-Xlint"
-)
+  "-Xlint")
 Compile / javacOptions ++= Seq("-Xlint:unchecked", "-Xlint:deprecation")
 
 Test / parallelExecution := false
@@ -30,7 +27,7 @@ val AkkaHttpVersion = "10.2.4"
 val AkkaManagementVersion = "1.0.10"
 val AkkaPersistenceJdbcVersion = "5.0.0"
 val AlpakkaKafkaVersion = "2.0.7"
-val AkkaProjectionVersion = "1.1.0"
+val AkkaProjectionVersion = "1.2.2"
 val ScalikeJdbcVersion = "3.5.0"
 
 enablePlugins(AkkaGrpcPlugin)
@@ -75,5 +72,4 @@ libraryDependencies ++= Seq(
   "org.scalikejdbc" %% "scalikejdbc" % ScalikeJdbcVersion,
   "org.scalikejdbc" %% "scalikejdbc-config" % ScalikeJdbcVersion,
   "com.typesafe.akka" %% "akka-stream-kafka" % AlpakkaKafkaVersion,
-  "com.lightbend.akka" %% "akka-projection-testkit" % AkkaProjectionVersion % Test
-)
+  "com.lightbend.akka" %% "akka-projection-testkit" % AkkaProjectionVersion % Test)

--- a/docs-source/docs/modules/microservices-tutorial/examples/shopping-cart-service-java/ddl-scripts/create_tables.sql
+++ b/docs-source/docs/modules/microservices-tutorial/examples/shopping-cart-service-java/ddl-scripts/create_tables.sql
@@ -65,4 +65,14 @@ CREATE TABLE IF NOT EXISTS public.akka_projection_offset_store (
     PRIMARY KEY(projection_name, projection_key)
     );
 
-CREATE INDEX IF NOT EXISTS projection_name_index ON akka_projection_offset_store (projection_name);
+CREATE INDEX IF NOT EXISTS projection_name_index ON public.akka_projection_offset_store (projection_name);
+
+--drop table if exists public.akka_projection_management;
+
+CREATE TABLE IF NOT EXISTS public.akka_projection_management (
+  projection_name VARCHAR(255) NOT NULL,
+  projection_key VARCHAR(255) NOT NULL,
+  paused BOOLEAN NOT NULL,
+  last_updated BIGINT NOT NULL,
+  PRIMARY KEY(projection_name, projection_key)
+);

--- a/docs-source/docs/modules/microservices-tutorial/examples/shopping-cart-service-scala/build.sbt
+++ b/docs-source/docs/modules/microservices-tutorial/examples/shopping-cart-service-scala/build.sbt
@@ -2,9 +2,7 @@ name := "shopping-cart-service"
 
 organization := "com.lightbend.akka.samples"
 organizationHomepage := Some(url("https://akka.io"))
-licenses := Seq(
-  ("CC0", url("https://creativecommons.org/publicdomain/zero/1.0"))
-)
+licenses := Seq(("CC0", url("https://creativecommons.org/publicdomain/zero/1.0")))
 
 scalaVersion := "2.13.5"
 
@@ -14,8 +12,7 @@ Compile / scalacOptions ++= Seq(
   "-feature",
   "-unchecked",
   "-Xlog-reflective-calls",
-  "-Xlint"
-)
+  "-Xlint")
 Compile / javacOptions ++= Seq("-Xlint:unchecked", "-Xlint:deprecation")
 
 Test / parallelExecution := false
@@ -30,7 +27,7 @@ val AkkaHttpVersion = "10.2.4"
 val AkkaManagementVersion = "1.0.10"
 val AkkaPersistenceJdbcVersion = "5.0.0"
 val AlpakkaKafkaVersion = "2.0.7"
-val AkkaProjectionVersion = "1.1.0"
+val AkkaProjectionVersion = "1.2.2"
 val ScalikeJdbcVersion = "3.5.0"
 
 enablePlugins(AkkaGrpcPlugin)
@@ -75,5 +72,4 @@ libraryDependencies ++= Seq(
   "org.scalikejdbc" %% "scalikejdbc" % ScalikeJdbcVersion,
   "org.scalikejdbc" %% "scalikejdbc-config" % ScalikeJdbcVersion,
   "com.typesafe.akka" %% "akka-stream-kafka" % AlpakkaKafkaVersion,
-  "com.lightbend.akka" %% "akka-projection-testkit" % AkkaProjectionVersion % Test
-)
+  "com.lightbend.akka" %% "akka-projection-testkit" % AkkaProjectionVersion % Test)

--- a/docs-source/docs/modules/microservices-tutorial/examples/shopping-cart-service-scala/ddl-scripts/create_tables.sql
+++ b/docs-source/docs/modules/microservices-tutorial/examples/shopping-cart-service-scala/ddl-scripts/create_tables.sql
@@ -65,4 +65,14 @@ CREATE TABLE IF NOT EXISTS public.akka_projection_offset_store (
     PRIMARY KEY(projection_name, projection_key)
     );
 
-CREATE INDEX IF NOT EXISTS projection_name_index ON akka_projection_offset_store (projection_name);
+CREATE INDEX IF NOT EXISTS projection_name_index ON public.akka_projection_offset_store (projection_name);
+
+--drop table if exists public.akka_projection_management;
+
+CREATE TABLE IF NOT EXISTS public.akka_projection_management (
+  projection_name VARCHAR(255) NOT NULL,
+  projection_key VARCHAR(255) NOT NULL,
+  paused BOOLEAN NOT NULL,
+  last_updated BIGINT NOT NULL,
+  PRIMARY KEY(projection_name, projection_key)
+);

--- a/docs-source/docs/modules/microservices-tutorial/examples/shopping-order-service-scala/build.sbt
+++ b/docs-source/docs/modules/microservices-tutorial/examples/shopping-order-service-scala/build.sbt
@@ -2,9 +2,7 @@ name := "shopping-order-service"
 
 organization := "com.lightbend.akka.samples"
 organizationHomepage := Some(url("https://akka.io"))
-licenses := Seq(
-  ("CC0", url("https://creativecommons.org/publicdomain/zero/1.0"))
-)
+licenses := Seq(("CC0", url("https://creativecommons.org/publicdomain/zero/1.0")))
 
 scalaVersion := "2.13.5"
 
@@ -14,8 +12,7 @@ Compile / scalacOptions ++= Seq(
   "-feature",
   "-unchecked",
   "-Xlog-reflective-calls",
-  "-Xlint"
-)
+  "-Xlint")
 Compile / javacOptions ++= Seq("-Xlint:unchecked", "-Xlint:deprecation")
 
 Test / parallelExecution := false
@@ -30,7 +27,7 @@ val AkkaHttpVersion = "10.2.4"
 val AkkaManagementVersion = "1.0.10"
 val AkkaPersistenceJdbcVersion = "5.0.0"
 val AlpakkaKafkaVersion = "2.0.7"
-val AkkaProjectionVersion = "1.1.0"
+val AkkaProjectionVersion = "1.2.2"
 val ScalikeJdbcVersion = "3.5.0"
 
 enablePlugins(AkkaGrpcPlugin)
@@ -75,5 +72,4 @@ libraryDependencies ++= Seq(
   "org.scalikejdbc" %% "scalikejdbc" % ScalikeJdbcVersion,
   "org.scalikejdbc" %% "scalikejdbc-config" % ScalikeJdbcVersion,
   "com.typesafe.akka" %% "akka-stream-kafka" % AlpakkaKafkaVersion,
-  "com.lightbend.akka" %% "akka-projection-testkit" % AkkaProjectionVersion % Test
-)
+  "com.lightbend.akka" %% "akka-projection-testkit" % AkkaProjectionVersion % Test)


### PR DESCRIPTION
* introduced in Akka Projections 1.2.0

The samples already use akka-platform-dependencies 0.1.6, which is Akka Projections 1.2.1: https://github.com/lightbend/akka-platform-dependencies/blob/v0.1.6/project/Dependencies.scala#L13